### PR TITLE
Add error handling to BTC price hook

### DIFF
--- a/src/hook/BTC.jsx
+++ b/src/hook/BTC.jsx
@@ -4,9 +4,21 @@ export function UseBTCPrice() {
   const [price, setPrice] = useState(null);
 
   useEffect(() => {
-    fetch('https://api.coindesk.com/v1/bpi/currentprice/EUR.json')
-      .then(response => response.json())
-      .then(data => setPrice(data.bpi.EUR.rate_float));
+    const fetchPrice = async () => {
+      try {
+        const response = await fetch('https://api.coindesk.com/v1/bpi/currentprice/EUR.json');
+        if (!response.ok) {
+          throw new Error(`Network response was not ok: ${response.status}`);
+        }
+        const data = await response.json();
+        setPrice(data.bpi.EUR.rate_float);
+      } catch (error) {
+        console.error('Failed to fetch BTC price:', error);
+        setPrice(null);
+      }
+    };
+
+    fetchPrice();
   }, []);
 
   return price;


### PR DESCRIPTION
## Summary
- add async fetchPrice with try/catch in `UseBTCPrice` hook
- log network errors and default `price` to `null`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6843cbaa4c148323a4459b2241bc5fe6