### PR TITLE
Update README for BTC calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,31 @@
-# React + Vite
+# BTC Calculator
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project is a small Bitcoin calculator built with React and Vite. It lets you check how much BTC you can withdraw each month based on your wallet balance, the amount you want to keep untouched, and a target date. Current BTC price data is fetched from CoinDesk.
 
-Currently, two official plugins are available:
+## Setup
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+1. Install [Node.js](https://nodejs.org/) (version 18 or later is recommended).
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The app will be available at `http://localhost:5173` by default.
+
+## Development Commands
+
+- `npm run dev` – start the Vite dev server with hot reload.
+- `npm run build` – build the production bundle.
+- `npm run preview` – preview the production build locally.
+- `npm run lint` – run ESLint on the project files.
+
+## Project Structure
+
+The main React code lives in `src/`. `App.jsx` holds the calculator logic and renders header, inputs, and results. `src/hook/BTC.jsx` provides a hook to retrieve the current BTC price.
+
+## License
+
+This project is provided as-is without warranty.


### PR DESCRIPTION
## Summary
- replace the template README with instructions for the BTC calculator

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843cbab6c608323a2e9d988012a9e0f