### PR TITLE
Rename Calculator component export

### DIFF
--- a/src/components/Calculator/Calculator.jsx
+++ b/src/components/Calculator/Calculator.jsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 
 
-export function App() {
+export function Calculator() {
     // Estados para almacenar los valores de los inputs
     const [walletValue, setWalletValue] = useState(0);
     const [btcIntocableValue, setBtcIntocableValue] = useState(0);


### PR DESCRIPTION
## Summary
- rename the function exported from `Calculator.jsx` to `Calculator`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843cba9a5dc8323be085b6fc4dbc46e