### PR TITLE
Fix division by zero in BTC calculator

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,7 +23,9 @@ function App() {
 
   // Función para calcular el valor total de los BTC en base a los inputs
   const calculateTotalBTCValue = () => {
-    return (walletAmount - btcIntocableAmount) / calculateMonthsDifference()*-1;
+    const months = calculateMonthsDifference();
+    if (months === 0) return 0; // Evitar divisiones por cero
+    return ((walletAmount - btcIntocableAmount) / months) * -1;
   };
 
   return (


### PR DESCRIPTION
## Summary
- avoid dividing by zero when no difference in months

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6843c98713c08323a40309d5853a7a4a