### PR TITLE
Fix divide by zero in BTC calculator

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import './App.css';
 import { UseBTCPrice } from './hook/BTC';
 import Header from './components/Header/Header';
@@ -18,12 +18,16 @@ function App() {
     const currentDate = new Date();
     const parsedSelectedDate = new Date(selectedDate);
 
-    return differenceInMonths(currentDate, parsedSelectedDate);
+    return differenceInMonths(parsedSelectedDate, currentDate);
   };
 
   // Función para calcular el valor total de los BTC en base a los inputs
+  const monthsDifference = calculateMonthsDifference();
+  const displayMonths = monthsDifference > 0 ? monthsDifference : 0;
+
   const calculateTotalBTCValue = () => {
-    return (walletAmount - btcIntocableAmount) / calculateMonthsDifference()*-1;
+    if (monthsDifference <= 0) return 0;
+    return (walletAmount - btcIntocableAmount) / monthsDifference;
   };
 
   return (
@@ -40,7 +44,7 @@ function App() {
           onChange={(e) => setSelectedDate(e.target.value)} 
         /></p>
       <div>
-        <p>Meses transcurridos desde la fecha seleccionada: {calculateMonthsDifference()*-1}</p>
+        <p>Meses transcurridos desde la fecha seleccionada: {displayMonths}</p>
       </div>
       <div>
         <p>Wallet</p>


### PR DESCRIPTION
## Summary
- handle zero or negative month difference in `calculateTotalBTCValue`
- calculate months difference once and reuse in display
- compute month difference using correct date order and remove unused import

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ca5afde883238315eedaf9a24475