### PR TITLE
Improve BTC price hook error handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
-import { UseBTCPrice } from './hook/BTC';
+import { useBTCPrice } from './hook/BTC';
 import Header from './components/Header/Header';
 import { differenceInMonths } from 'date-fns';
 
@@ -10,7 +10,7 @@ function App() {
   // Definir los estados para los valores de los inputs y el resultado del cálculo
   const [walletAmount, setWalletAmount] = useState(0);
   const [btcIntocableAmount, setBTCIntocableAmount] = useState(0);
-  const btcPrice = UseBTCPrice();
+  const btcPrice = useBTCPrice();
   const [selectedDate, setSelectedDate] = useState('');
   const calculateMonthsDifference = () => {
     if (!selectedDate) return 0; // Si no se ha seleccionado ninguna fecha, retornar 0
@@ -31,7 +31,7 @@ function App() {
       <Header />
       <div className='principal'>
       <div>
-        <p>Precio de BTC: {btcPrice}</p>
+        <p>Precio de BTC: {btcPrice ? btcPrice : 'Cargando…'}</p>
       </div>
       <p>Fecha actual: {new Date().toLocaleDateString()}</p>
       <p>Fecha Final seleccionar: <input 
@@ -54,7 +54,7 @@ function App() {
         <p>BTC mensual para retirar: {calculateTotalBTCValue()}</p>
       </div>
       <div>
-        <p>Valor total de EUR: {(calculateTotalBTCValue() * btcPrice).toFixed(2)}</p>
+        <p>Valor total de EUR: {btcPrice ? (calculateTotalBTCValue() * btcPrice).toFixed(2) : 'Cargando…'}</p>
       </div>
       </div>
     </>

--- a/src/components/Calculator/Calculator.jsx
+++ b/src/components/Calculator/Calculator.jsx
@@ -1,4 +1,4 @@
-import { UseBTCPrice } from "../../hook/BTC";
+import { useBTCPrice } from "../../hook/BTC";
 import { useState } from "react";
 
 

--- a/src/hook/BTC.jsx
+++ b/src/hook/BTC.jsx
@@ -1,12 +1,23 @@
 import React, { useState, useEffect } from 'react';
 
-export function UseBTCPrice() {
+export function useBTCPrice() {
   const [price, setPrice] = useState(null);
 
   useEffect(() => {
-    fetch('https://api.coindesk.com/v1/bpi/currentprice/EUR.json')
-      .then(response => response.json())
-      .then(data => setPrice(data.bpi.EUR.rate_float));
+    const fetchPrice = async () => {
+      try {
+        const response = await fetch(
+          'https://api.coindesk.com/v1/bpi/currentprice/EUR.json'
+        );
+        const data = await response.json();
+        setPrice(data.bpi.EUR.rate_float);
+      } catch (error) {
+        console.error('Failed to fetch BTC price:', error);
+        setPrice(0);
+      }
+    };
+
+    fetchPrice();
   }, []);
 
   return price;


### PR DESCRIPTION
## Summary
- handle BTC fetch errors using async/await
- show a placeholder while the BTC price loads

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6843cb7e10a083238a339743c625a46a