### PR TITLE
refactor: encapsulate calculator form component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,63 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import './App.css';
-import { UseBTCPrice } from './hook/BTC';
 import Header from './components/Header/Header';
-import { differenceInMonths } from 'date-fns';
-
-
+import { Calculator } from './components/Calculator/Calculator';
 
 function App() {
-  // Definir los estados para los valores de los inputs y el resultado del cálculo
-  const [walletAmount, setWalletAmount] = useState(0);
-  const [btcIntocableAmount, setBTCIntocableAmount] = useState(0);
-  const btcPrice = UseBTCPrice();
-  const [selectedDate, setSelectedDate] = useState('');
-  const calculateMonthsDifference = () => {
-    if (!selectedDate) return 0; // Si no se ha seleccionado ninguna fecha, retornar 0
-
-    const currentDate = new Date();
-    const parsedSelectedDate = new Date(selectedDate);
-
-    return differenceInMonths(currentDate, parsedSelectedDate);
-  };
-
-  // Función para calcular el valor total de los BTC en base a los inputs
-  const calculateTotalBTCValue = () => {
-    const months = calculateMonthsDifference();
-    if (months === 0) return 0; // Evitar divisiones por cero
-    return ((walletAmount - btcIntocableAmount) / months) * -1;
-  };
-
   return (
     <>
       <Header />
       <div className='principal'>
-      <div>
-        <p>Precio de BTC: {btcPrice}</p>
-      </div>
-      <p>Fecha actual: {new Date().toLocaleDateString()}</p>
-      <p>Fecha Final seleccionar: <input 
-          type="date" 
-          value={selectedDate} 
-          onChange={(e) => setSelectedDate(e.target.value)} 
-        /></p>
-      <div>
-        <p>Meses transcurridos desde la fecha seleccionada: {calculateMonthsDifference()*-1}</p>
-      </div>
-      <div>
-        <p>Wallet</p>
-        <input type="number" value={walletAmount} onChange={(e) => setWalletAmount(parseFloat(e.target.value))} />
-      </div>
-      <div>
-        <p>BTC Intocable</p>
-        <input type="number" value={btcIntocableAmount} onChange={(e) => setBTCIntocableAmount(parseFloat(e.target.value))} />
-      </div>
-      <div>
-        <p>BTC mensual para retirar: {calculateTotalBTCValue()}</p>
-      </div>
-      <div>
-        <p>Valor total de EUR: {(calculateTotalBTCValue() * btcPrice).toFixed(2)}</p>
-      </div>
+        <Calculator />
       </div>
     </>
   );

--- a/src/components/Calculator/Calculator.css
+++ b/src/components/Calculator/Calculator.css
@@ -1,0 +1,23 @@
+.calculator {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.error {
+  color: red;
+  font-size: 0.8rem;
+}
+
+.help {
+  font-size: 0.8rem;
+  color: #666;
+}

--- a/src/components/Calculator/Calculator.jsx
+++ b/src/components/Calculator/Calculator.jsx
@@ -1,5 +1,7 @@
 import { UseBTCPrice } from "../../hook/BTC";
 import { useState } from "react";
+import { differenceInMonths } from "date-fns";
+import "./Calculator.css";
 
 
 
@@ -7,14 +9,115 @@ export function Calculator() {
     // Estados para almacenar los valores de los inputs
     const [walletValue, setWalletValue] = useState(0);
     const [btcIntocableValue, setBtcIntocableValue] = useState(0);
-  
+    const [selectedDate, setSelectedDate] = useState("");
+    const btcPrice = UseBTCPrice();
+
     // Función para manejar el cambio en el input de la wallet
     const handleWalletChange = (event) => {
       setWalletValue(parseFloat(event.target.value)); // Convertimos el valor a número flotante
     };
-  
+
     // Función para manejar el cambio en el input de BTC Intocable
     const handleBtcIntocableChange = (event) => {
       setBtcIntocableValue(parseFloat(event.target.value)); // Convertimos el valor a número flotante
     };
-}  
+
+    // Función para manejar el cambio en la fecha seleccionada
+    const handleDateChange = (event) => {
+      setSelectedDate(event.target.value);
+    };
+
+    const calculateMonthsDifference = () => {
+      if (!selectedDate) return 0;
+      const currentDate = new Date();
+      const parsedSelectedDate = new Date(selectedDate);
+      return differenceInMonths(currentDate, parsedSelectedDate);
+    };
+
+    const monthsDifference = calculateMonthsDifference();
+    const validDate = selectedDate && monthsDifference < 0;
+
+    // Validaciones y mensajes de error
+    const walletError = walletValue < 0 ? "El valor debe ser positivo" : "";
+    const btcError =
+      btcIntocableValue < 0
+        ? "El valor debe ser positivo"
+        : btcIntocableValue > walletValue
+        ? "No puede superar el total"
+        : "";
+    const dateError =
+      selectedDate === ""
+        ? "Selecciona una fecha"
+        : monthsDifference >= 0
+        ? "La fecha debe ser futura"
+        : "";
+
+    // Función para calcular el valor total de los BTC en base a los inputs
+    const calculateTotalBTCValue = () => {
+      if (!validDate) return 0; // Evitar divisiones por cero o fechas inválidas
+      return ((walletValue - btcIntocableValue) / monthsDifference) * -1;
+    };
+
+    return (
+      <form className="calculator" onSubmit={(e) => e.preventDefault()}>
+        <div className="field">
+          <label>Precio de BTC: {btcPrice}</label>
+        </div>
+
+        <div className="field">
+          <label htmlFor="date">Fecha final</label>
+          <input
+            id="date"
+            type="date"
+            value={selectedDate}
+            onChange={handleDateChange}
+          />
+          {dateError ? (
+            <p className="error">{dateError}</p>
+          ) : (
+            <p className="help">Selecciona la fecha final</p>
+          )}
+        </div>
+
+        <div className="field">
+          <label htmlFor="wallet">Wallet</label>
+          <input
+            id="wallet"
+            type="number"
+            value={walletValue}
+            onChange={handleWalletChange}
+          />
+          {walletError ? (
+            <p className="error">{walletError}</p>
+          ) : (
+            <p className="help">Total de BTC en la wallet</p>
+          )}
+        </div>
+
+        <div className="field">
+          <label htmlFor="btc">BTC Intocable</label>
+          <input
+            id="btc"
+            type="number"
+            value={btcIntocableValue}
+            onChange={handleBtcIntocableChange}
+          />
+          {btcError ? (
+            <p className="error">{btcError}</p>
+          ) : (
+            <p className="help">Cantidad de BTC que no se puede retirar</p>
+          )}
+        </div>
+
+        <div className="field">
+          <p>BTC mensual para retirar: {calculateTotalBTCValue()}</p>
+        </div>
+
+        <div className="field">
+          <p>
+            Valor total de EUR: {(calculateTotalBTCValue() * btcPrice).toFixed(2)}
+          </p>
+        </div>
+      </form>
+    );
+}


### PR DESCRIPTION
## Summary
- add a form-based Calculator component with basic validations and help messages
- style Calculator component
- use the new Calculator in App for clearer separation of concerns

## Testing
- `npm test`
- `npm run lint`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68ab5c694ba8832384433aa0399c8c44