### PR TITLE
feat: implement localStorage hook

### DIFF
--- a/src/hook/LocalStorage.jsx
+++ b/src/hook/LocalStorage.jsx
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook para sincronizar un estado con localStorage.
+ *
+ * @param {string} key Clave donde se almacenará el valor.
+ * @param {*} initialValue Valor inicial usado si no existe nada en localStorage.
+ * @returns {[any, Function]} Par con el valor almacenado y una función para actualizarlo.
+ */
+export function UseLocalStorage(key, initialValue) {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(storedValue));
+    } catch {
+      // Ignorar errores de escritura
+    }
+  }, [key, storedValue]);
+
+  return [storedValue, setStoredValue];
+}
+


### PR DESCRIPTION
## Summary
- implement LocalStorage hook to sync state with browser storage

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Invalid option '--ext')

------
https://chatgpt.com/codex/tasks/task_e_68ab628be6848323808e917650df3ab2