### PR TITLE
Cache total BTC value computation

### DIFF
--- a/src/components/Calculator/Calculator.jsx
+++ b/src/components/Calculator/Calculator.jsx
@@ -57,6 +57,7 @@ export function Calculator() {
       if (!validDate) return 0; // Evitar divisiones por cero o fechas inválidas
       return ((walletValue - btcIntocableValue) / monthsDifference) * -1;
     };
+    const totalBTCValue = calculateTotalBTCValue();
 
     return (
       <form className="calculator" onSubmit={(e) => e.preventDefault()}>
@@ -110,12 +111,12 @@ export function Calculator() {
         </div>
 
         <div className="field">
-          <p>BTC mensual para retirar: {calculateTotalBTCValue()}</p>
+          <p>BTC mensual para retirar: {totalBTCValue}</p>
         </div>
 
         <div className="field">
           <p>
-            Valor total de EUR: {(calculateTotalBTCValue() * btcPrice).toFixed(2)}
+            Valor total de EUR: {(totalBTCValue * btcPrice).toFixed(2)}
           </p>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- Compute `calculateTotalBTCValue` once and reuse cached result in `Calculator`

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot read properties of undefined (reading 'recommended'))*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Expected ';' but found 'BTCState')*


------
https://chatgpt.com/codex/tasks/task_e_68ab628a77148323a3cc1b1179f2842f