### PR TITLE
Validate numeric inputs

### DIFF
--- a/src/components/Calculator/Calculator.jsx
+++ b/src/components/Calculator/Calculator.jsx
@@ -14,12 +14,14 @@ export function Calculator() {
 
     // Función para manejar el cambio en el input de la wallet
     const handleWalletChange = (event) => {
-      setWalletValue(parseFloat(event.target.value)); // Convertimos el valor a número flotante
+      const value = Number(event.target.value);
+      setWalletValue(Number.isNaN(value) ? 0 : value);
     };
 
     // Función para manejar el cambio en el input de BTC Intocable
     const handleBtcIntocableChange = (event) => {
-      setBtcIntocableValue(parseFloat(event.target.value)); // Convertimos el valor a número flotante
+      const value = Number(event.target.value);
+      setBtcIntocableValue(Number.isNaN(value) ? 0 : value);
     };
 
     // Función para manejar el cambio en la fecha seleccionada


### PR DESCRIPTION
## Summary
- avoid NaN values by using `Number` to parse wallet fields and defaulting invalid inputs to 0

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext' with eslint.config.js)*
- `npx eslint .` *(fails: Cannot read properties of undefined 'recommended')*


------
https://chatgpt.com/codex/tasks/task_e_68ab6289989c8323b32ddcb8c4e926c8