### PR TITLE
feat: add Bitcoin price hook

### DIFF
--- a/src/hooks/useBTCPrice.js
+++ b/src/hooks/useBTCPrice.js
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Custom hook to fetch current Bitcoin price.
+ * @param {('USD'|'EUR')} currency - Currency code.
+ * @param {number} [refreshMs=60000] - Refresh interval in milliseconds. Set to 0 to disable auto refresh.
+ * @returns {{price: number|null, loading: boolean, error: string|null, refetch: () => Promise<void>}}
+ */
+export default function useBTCPrice(currency = 'USD', refreshMs = 60000) {
+  const [price, setPrice] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const intervalRef = useRef(null);
+
+  const fetchPrice = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=${currency.toLowerCase()}`);
+      if (!res.ok) throw new Error(`Error ${res.status}`);
+      const data = await res.json();
+      const value = data?.bitcoin?.[currency.toLowerCase()];
+      if (!Number.isFinite(value)) throw new Error('Precio no disponible');
+      setPrice(value);
+    } catch (err) {
+      setError(err.message || 'Error desconocido');
+      setPrice(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPrice();
+    if (refreshMs > 0) {
+      intervalRef.current = setInterval(fetchPrice, refreshMs);
+      return () => clearInterval(intervalRef.current);
+    }
+    return undefined;
+  }, [currency, refreshMs]);
+
+  return { price, loading, error, refetch: fetchPrice };
+}
+


### PR DESCRIPTION
## Summary
- add useBTCPrice hook to fetch BTC price in USD or EUR with loading/error state and periodic refresh

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext' with eslint.config.js)*
- `npx eslint src/hooks/useBTCPrice.js` *(fails: Cannot read properties of undefined (reading 'recommended'))*

------
https://chatgpt.com/codex/tasks/task_e_68ab646df178832396caeaa8376ec751