### PR TITLE
Add mobile dashboard with BTC balance

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import './App.css';
 import Header from './components/Header/Header';
 import { Calculator } from './components/Calculator/Calculator';
+import { Dashboard } from './components/Dashboard/Dashboard';
 
 function App() {
   return (
@@ -9,9 +10,11 @@ function App() {
       <Header />
       <div className='principal'>
         <Calculator />
+        <Dashboard />
       </div>
     </>
   );
 }
 
 export default App;
+

--- a/src/components/Dashboard/Dashboard.css
+++ b/src/components/Dashboard/Dashboard.css
@@ -1,0 +1,48 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
+.balance-card {
+  background: linear-gradient(135deg, #f7931a, #ffcc70);
+  color: #fff;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  text-align: center;
+}
+
+.interval-buttons {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.interval-buttons button {
+  flex: 1;
+  padding: 0.5rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: #eee;
+}
+
+.interval-buttons button.active {
+  background: linear-gradient(135deg, #f7931a, #ffcc70);
+  color: #fff;
+}
+

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import useBTCPrice from '../../hooks/useBTCPrice';
+import './Dashboard.css';
+
+export function Dashboard() {
+  const { price, loading, error } = useBTCPrice('EUR');
+  const [interval, setInterval] = useState('1D');
+  const intervals = ['1D', '1W', '1M', '1Y'];
+
+  return (
+    <div className="dashboard">
+      <div className="dashboard-header">
+        <img src="https://i.pravatar.cc/48" alt="Avatar" className="avatar" />
+        <span className="username">Usuario</span>
+      </div>
+      <div className="balance-card">
+        <h2>Balance actual</h2>
+        <p>
+          {loading ? 'Cargando...' : error ? error : `${price} EUR`}
+        </p>
+      </div>
+      <div className="interval-buttons">
+        {intervals.map((i) => (
+          <button
+            key={i}
+            type="button"
+            className={interval === i ? 'active' : ''}
+            onClick={() => setInterval(i)}
+          >
+            {i}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
 export * from "./Header/Header.jsx";
 export * from "./Image/Image.jsx";
 export * from "./Calculator/Calculator.jsx";
+export * from "./Dashboard/Dashboard.jsx";


### PR DESCRIPTION
## Summary
- add Dashboard component with avatar, BTC balance card, and interval buttons
- style Dashboard for mobile with gradient background and rounded corners
- render Dashboard in App

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Invalid option '--ext' / config issue)*
- `npx eslint .` *(fails: Cannot read property 'recommended' of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68ab69e974d083238b90e0f65ae94c52