### PR TITLE
Add dashboard bar chart with Recharts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "date-fns": "^3.6.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "recharts": "^2.10.4"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -1,0 +1,41 @@
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
+
+// Dataset ficticio de ganancias y pérdidas mensuales
+const data = [
+  { month: "Ene", value: 400 },
+  { month: "Feb", value: -200 },
+  { month: "Mar", value: 1000 },
+  { month: "Abr", value: -800 },
+  { month: "May", value: 650 },
+];
+
+// Subcomponente que muestra un gráfico de barras de ganancias/pérdidas
+function ProfitLossChart() {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data}>
+        <defs>
+          <linearGradient id="profitGradient" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#646cff" />
+            <stop offset="100%" stopColor="#42a5f5" />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+        <XAxis dataKey="month" axisLine={false} tickLine={false} />
+        <YAxis allowDecimals={false} axisLine={false} tickLine={false} />
+        <Tooltip />
+        <Bar dataKey="value" fill="url(#profitGradient)" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function Dashboard() {
+  return (
+    <section>
+      <h2>Profit &amp; Loss</h2>
+      <ProfitLossChart />
+    </section>
+  );
+}
+

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
 export * from "./Header/Header.jsx";
 export * from "./Image/Image.jsx";
 export * from "./Calculator/Calculator.jsx";
+export * from "./Dashboard/Dashboard.jsx";


### PR DESCRIPTION
## Summary
- add `recharts` dependency for charting
- create `Dashboard` component with `ProfitLossChart` bar chart
- export Dashboard from components index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext' for eslint.config.js)*


------
https://chatgpt.com/codex/tasks/task_e_68ab69ecc6688323a36c252316556460