### PR TITLE
feat: refresh layout and add btc planning tools

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,46 +1,85 @@
 #root {
-  max-width: 1280px;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  color: var(--foreground);
+}
+
+.content-grid {
+  width: min(1200px, calc(100% - 3rem));
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+  padding: 2rem 0 4rem;
+  display: grid;
+  gap: 2rem;
 }
 
 .card {
-  padding: 2em;
+  border-radius: 1.5rem;
+  padding: 2rem;
+  background: rgba(10, 14, 26, 0.65);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(14px);
 }
 
-.read-the-docs {
-  color: #888;
+.primary-button,
+.secondary-button,
+.ghost-button {
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.principal {
-  margin-top: 100px;
+.primary-button {
+  background: linear-gradient(135deg, #f7931a, #ffb347);
+  color: #1c1c1c;
+}
+
+.secondary-button {
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+}
+
+.ghost-button {
+  background: transparent;
+  color: var(--muted-foreground);
+}
+
+.primary-button:hover,
+.secondary-button:hover,
+.ghost-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
+}
+
+.primary-button:focus,
+.secondary-button:focus,
+.ghost-button:focus {
+  outline: 2px solid rgba(247, 147, 26, 0.6);
+  outline-offset: 2px;
+}
+
+@media (min-width: 1024px) {
+  .content-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+}
+
+@media (max-width: 600px) {
+  .content-grid {
+    width: calc(100% - 2rem);
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,18 +1,97 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import './App.css';
 import Header from './components/Header/Header';
 import { Calculator } from './components/Calculator/Calculator';
 import { Dashboard } from './components/Dashboard/Dashboard';
+import { UseBTCPrice } from './hooks/btc';
+
+const HISTORY_STORAGE_KEY = 'btc-history';
+const MAX_HISTORY_POINTS = 30;
+
+const safeParseHistory = value => {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map(item => ({
+        time: typeof item?.time === 'string' ? item.time : null,
+        price: Number(item?.price),
+      }))
+      .filter(item => item.time && Number.isFinite(item.price));
+  } catch (error) {
+    return [];
+  }
+};
 
 function App() {
+  const { price, source, loading, error, lastUpdated, refresh } = UseBTCPrice();
+  const [history, setHistory] = useState(() => {
+    if (typeof window === 'undefined') return [];
+    return safeParseHistory(window.localStorage.getItem(HISTORY_STORAGE_KEY));
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history));
+  }, [history]);
+
+  useEffect(() => {
+    if (price === null || !lastUpdated) return;
+    setHistory(prevHistory => {
+      const lastEntry = prevHistory.at(-1);
+      if (lastEntry && lastEntry.time === lastUpdated) {
+        return prevHistory;
+      }
+
+      const nextHistory = [...prevHistory, { time: lastUpdated, price }];
+      if (nextHistory.length > MAX_HISTORY_POINTS) {
+        return nextHistory.slice(nextHistory.length - MAX_HISTORY_POINTS);
+      }
+      return nextHistory;
+    });
+  }, [price, lastUpdated]);
+
+  const clearHistory = useCallback(() => {
+    setHistory([]);
+  }, []);
+
+  const chartData = useMemo(
+    () =>
+      history.map(entry => ({
+        time: new Date(entry.time).toLocaleTimeString('es-ES', {
+          hour: '2-digit',
+          minute: '2-digit',
+        }),
+        price: entry.price,
+      })),
+    [history]
+  );
+
   return (
-    <>
+    <div className="app-shell">
       <Header />
-      <div className='principal'>
-        <Calculator />
-        <Dashboard username="Ada Lovelace" avatarUrl="https://i.pravatar.cc/100?img=5" />
-      </div>
-    </>
+      <main className="content-grid">
+        <Calculator
+          price={price}
+          source={source}
+          loading={loading}
+          error={error}
+          lastUpdated={lastUpdated}
+          onRefresh={refresh}
+        />
+        <Dashboard
+          username="Ada Lovelace"
+          avatarUrl="https://i.pravatar.cc/100?img=5"
+          history={chartData}
+          rawHistory={history}
+          price={price}
+          source={source}
+          lastUpdated={lastUpdated}
+          onClearHistory={clearHistory}
+        />
+      </main>
+    </div>
   );
 }
 

--- a/src/components/Calculator/Calculator.css
+++ b/src/components/Calculator/Calculator.css
@@ -1,23 +1,212 @@
 .calculator {
   display: flex;
   flex-direction: column;
+  gap: 1.5rem;
+}
+
+.calculator__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   gap: 1rem;
-  max-width: 400px;
-  margin: 0 auto;
+}
+
+.calculator__subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--muted-foreground);
+}
+
+.calculator__price {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  font-weight: 600;
+}
+
+.calculator__price-value {
+  font-size: 1.5rem;
+}
+
+.calculator__price-source,
+.calculator__price-updated {
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--muted-foreground);
+}
+
+.calculator__errors {
+  border: 1px solid #ff5f5f;
+  border-radius: 0.8rem;
+  padding: 1rem;
+  background: rgba(255, 95, 95, 0.1);
+}
+
+.calculator__errors h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.calculator__errors ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.calculator__form {
+  display: grid;
+  gap: 1rem;
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  gap: 0.4rem;
+}
+
+.field input,
+.field select,
+.calculator__profile-form input {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.02);
+  color: inherit;
+}
+
+.field input:focus,
+.field select:focus,
+.calculator__profile-form input:focus {
+  outline: 2px solid rgba(247, 147, 26, 0.6);
+  border-color: transparent;
 }
 
 .error {
-  color: red;
-  font-size: 0.8rem;
+  color: #ff5f5f;
+  font-size: 0.85rem;
+  margin: 0;
 }
 
 .help {
-  font-size: 0.8rem;
-  color: #666;
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+  margin: 0;
+}
+
+.calculator__result {
+  display: grid;
+  gap: 0.25rem;
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(247, 147, 26, 0.15), rgba(247, 147, 26, 0.05));
+}
+
+.calculator__result h3 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+}
+
+.calculator__result-value {
+  font-size: 2rem;
+  margin: 0;
+  font-weight: 700;
+}
+
+.calculator__result-eur {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--muted-foreground);
+}
+
+.calculator__profiles {
+  display: grid;
+  gap: 1rem;
+}
+
+.calculator__profiles-header h3 {
+  margin-bottom: 0.25rem;
+}
+
+.calculator__profile-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.calculator__profile-form input {
+  flex: 1 1 220px;
+}
+
+.calculator__profiles-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.calculator__profile-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.calculator__profile-item h4 {
+  margin: 0 0 0.5rem;
+}
+
+.calculator__profile-item dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.calculator__profile-item dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+}
+
+.calculator__profile-item dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.calculator__profile-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.visualmente-oculto {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .calculator__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .calculator__profile-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }

--- a/src/components/Calculator/Calculator.jsx
+++ b/src/components/Calculator/Calculator.jsx
@@ -1,101 +1,251 @@
-import { UseBTCPrice } from "../../hooks/btc";
-import { useEffect, useState } from "react";
-import { differenceInMonths } from "date-fns";
+import { useEffect, useMemo, useState } from "react";
+import { differenceInMonths, differenceInWeeks } from "date-fns";
 import "./Calculator.css";
 
+const sourceLabels = {
+  coindesk: "CoinDesk",
+  coingecko: "CoinGecko",
+  binance: "Binance",
+};
 
+const btcFormatter = new Intl.NumberFormat("es-ES", {
+  minimumFractionDigits: 6,
+  maximumFractionDigits: 6,
+});
 
-export function Calculator() {
-    const readNumberFromStorage = (key) => {
-      if (typeof window === "undefined") return 0;
-      const storedValue = window.localStorage.getItem(key);
-      const parsedValue = Number(storedValue);
-      return Number.isFinite(parsedValue) ? parsedValue : 0;
+const eurFormatter = new Intl.NumberFormat("es-ES", {
+  style: "currency",
+  currency: "EUR",
+  maximumFractionDigits: 2,
+});
+
+const PROFILE_STORAGE_KEY = "btc-profiles";
+
+const createProfileId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `profile-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const readProfiles = () => {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(PROFILE_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((profile) => typeof profile?.name === "string")
+      .map((profile) => ({
+        id: typeof profile?.id === "string" ? profile.id : createProfileId(),
+        name: profile.name,
+        walletValue: Number(profile?.walletValue) || 0,
+        btcIntocableValue: Number(profile?.btcIntocableValue) || 0,
+        selectedDate: typeof profile?.selectedDate === "string" ? profile.selectedDate : "",
+        frequency: profile?.frequency === "weekly" ? "weekly" : "monthly",
+      }));
+  } catch (error) {
+    return [];
+  }
+};
+
+export function Calculator({ price, source, loading, error, lastUpdated, onRefresh }) {
+  const readNumberFromStorage = (key) => {
+    if (typeof window === "undefined") return 0;
+    const storedValue = window.localStorage.getItem(key);
+    const parsedValue = Number(storedValue);
+    return Number.isFinite(parsedValue) ? parsedValue : 0;
+  };
+
+  const readStringFromStorage = (key) => {
+    if (typeof window === "undefined") return "";
+    return window.localStorage.getItem(key) ?? "";
+  };
+
+  const [walletValue, setWalletValue] = useState(() => readNumberFromStorage("walletValue"));
+  const [btcIntocableValue, setBtcIntocableValue] = useState(() =>
+    readNumberFromStorage("btcIntocableValue")
+  );
+  const [selectedDate, setSelectedDate] = useState(() => readStringFromStorage("selectedDate"));
+  const [frequency, setFrequency] = useState(() => {
+    if (typeof window === "undefined") return "monthly";
+    return window.localStorage.getItem("frequency") ?? "monthly";
+  });
+  const [profiles, setProfiles] = useState(() => readProfiles());
+  const [profileName, setProfileName] = useState("");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("walletValue", String(walletValue));
+  }, [walletValue]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("btcIntocableValue", String(btcIntocableValue));
+  }, [btcIntocableValue]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("selectedDate", selectedDate);
+  }, [selectedDate]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("frequency", frequency);
+  }, [frequency]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(profiles));
+  }, [profiles]);
+
+  const handleWalletChange = (event) => {
+    const value = Number(event.target.value);
+    setWalletValue(Number.isNaN(value) ? 0 : value);
+  };
+
+  const handleBtcIntocableChange = (event) => {
+    const value = Number(event.target.value);
+    setBtcIntocableValue(Number.isNaN(value) ? 0 : value);
+  };
+
+  const handleDateChange = (event) => {
+    setSelectedDate(event.target.value);
+  };
+
+  const handleFrequencyChange = (event) => {
+    setFrequency(event.target.value);
+  };
+
+  const calculatePeriodsDifference = () => {
+    if (!selectedDate) return 0;
+    const currentDate = new Date();
+    const parsedSelectedDate = new Date(selectedDate);
+    if (Number.isNaN(parsedSelectedDate.getTime())) return 0;
+    if (parsedSelectedDate <= currentDate) return 0;
+
+    if (frequency === "weekly") {
+      const diff = differenceInWeeks(parsedSelectedDate, currentDate);
+      return diff === 0 ? 1 : diff;
+    }
+
+    const diff = differenceInMonths(parsedSelectedDate, currentDate);
+    return diff === 0 ? 1 : diff;
+  };
+
+  const periodsDifference = calculatePeriodsDifference();
+  const validDate = Boolean(selectedDate) && periodsDifference > 0;
+  const periodLabel = frequency === "weekly" ? "semanal" : "mensual";
+
+  const walletError = walletValue < 0 ? "El valor debe ser positivo" : "";
+  const btcError =
+    btcIntocableValue < 0
+      ? "El valor debe ser positivo"
+      : btcIntocableValue > walletValue
+      ? "No puede superar el total"
+      : "";
+  const dateError =
+    selectedDate === ""
+      ? "Selecciona una fecha"
+      : !validDate
+      ? "La fecha debe ser futura"
+      : "";
+  const frequencyError = selectedDate && !validDate ? "La fecha debe ser futura" : "";
+
+  const calculateTotalBTCValue = () => {
+    if (!validDate) return 0;
+    const withdrawable = walletValue - btcIntocableValue;
+    if (withdrawable <= 0) return 0;
+    return withdrawable / periodsDifference;
+  };
+  const totalBTCValue = calculateTotalBTCValue();
+  const totalEURValue = price ? totalBTCValue * price : 0;
+
+  const aggregateErrors = useMemo(() => {
+    const unique = new Set(
+      [walletError, btcError, dateError, frequencyError].filter((message) => Boolean(message))
+    );
+    return Array.from(unique);
+  }, [walletError, btcError, dateError, frequencyError]);
+
+  const handleProfileSave = (event) => {
+    event.preventDefault();
+    if (!profileName.trim()) return;
+    const newProfile = {
+      id: createProfileId(),
+      name: profileName.trim(),
+      walletValue,
+      btcIntocableValue,
+      selectedDate,
+      frequency,
     };
+    setProfiles((prev) => [newProfile, ...prev].slice(0, 5));
+    setProfileName("");
+  };
 
-    const readStringFromStorage = (key) => {
-      if (typeof window === "undefined") return "";
-      return window.localStorage.getItem(key) ?? "";
-    };
+  const handleProfileLoad = (profile) => {
+    setWalletValue(profile.walletValue);
+    setBtcIntocableValue(profile.btcIntocableValue);
+    setSelectedDate(profile.selectedDate);
+    setFrequency(profile.frequency ?? "monthly");
+  };
 
-    // Estados para almacenar los valores de los inputs
-    const [walletValue, setWalletValue] = useState(() => readNumberFromStorage("walletValue"));
-    const [btcIntocableValue, setBtcIntocableValue] = useState(() => readNumberFromStorage("btcIntocableValue"));
-    const [selectedDate, setSelectedDate] = useState(() => readStringFromStorage("selectedDate"));
-    const { price: btcPrice, loading, error } = UseBTCPrice();
+  const handleProfileDelete = (id) => {
+    setProfiles((prev) => prev.filter((profile) => profile.id !== id));
+  };
 
-    useEffect(() => {
-      if (typeof window === "undefined") return;
-      window.localStorage.setItem("walletValue", String(walletValue));
-    }, [walletValue]);
-
-    useEffect(() => {
-      if (typeof window === "undefined") return;
-      window.localStorage.setItem("btcIntocableValue", String(btcIntocableValue));
-    }, [btcIntocableValue]);
-
-    useEffect(() => {
-      if (typeof window === "undefined") return;
-      window.localStorage.setItem("selectedDate", selectedDate);
-    }, [selectedDate]);
-
-    // Función para manejar el cambio en el input de la wallet
-    const handleWalletChange = (event) => {
-      const value = Number(event.target.value);
-      setWalletValue(Number.isNaN(value) ? 0 : value);
-    };
-
-    // Función para manejar el cambio en el input de BTC Intocable
-    const handleBtcIntocableChange = (event) => {
-      const value = Number(event.target.value);
-      setBtcIntocableValue(Number.isNaN(value) ? 0 : value);
-    };
-
-    // Función para manejar el cambio en la fecha seleccionada
-    const handleDateChange = (event) => {
-      setSelectedDate(event.target.value);
-    };
-
-    const calculateMonthsDifference = () => {
-      if (!selectedDate) return 0;
-      const currentDate = new Date();
-      const parsedSelectedDate = new Date(selectedDate);
-      return differenceInMonths(currentDate, parsedSelectedDate);
-    };
-
-    const monthsDifference = calculateMonthsDifference();
-    const validDate = selectedDate && monthsDifference < 0;
-
-    // Validaciones y mensajes de error
-    const walletError = walletValue < 0 ? "El valor debe ser positivo" : "";
-    const btcError =
-      btcIntocableValue < 0
-        ? "El valor debe ser positivo"
-        : btcIntocableValue > walletValue
-        ? "No puede superar el total"
-        : "";
-    const dateError =
-      selectedDate === ""
-        ? "Selecciona una fecha"
-        : monthsDifference >= 0
-        ? "La fecha debe ser futura"
-        : "";
-
-    // Función para calcular el valor total de los BTC en base a los inputs
-    const calculateTotalBTCValue = () => {
-      if (!validDate) return 0; // Evitar divisiones por cero o fechas inválidas
-      return ((walletValue - btcIntocableValue) / monthsDifference) * -1;
-    };
-    const totalBTCValue = calculateTotalBTCValue();
-
-    return (
-      <form className="calculator" onSubmit={(e) => e.preventDefault()}>
-        <div className="field">
-          <label>
-            Precio de BTC: {loading ? "Cargando…" : error ? error : btcPrice}
-          </label>
+  return (
+    <section className="calculator card" aria-labelledby="calculator-heading">
+      <header className="calculator__header">
+        <div>
+          <h2 id="calculator-heading">Planifica tus retiros</h2>
+          <p className="calculator__subtitle">
+            Ajusta los valores y guarda escenarios para compararlos después.
+          </p>
         </div>
+        <button type="button" onClick={() => onRefresh?.()} className="secondary-button">
+          Actualizar precio
+        </button>
+      </header>
 
+      <div className="calculator__price" role="status" aria-live="polite">
+        {loading ? (
+          <span>Cargando precio en tiempo real…</span>
+        ) : error ? (
+          <span className="error">{error}</span>
+        ) : (
+          <>
+            <span className="calculator__price-value">
+              {price ? eurFormatter.format(price) : "Sin datos"}
+            </span>
+            <span className="calculator__price-source">
+              Fuente: {source ? sourceLabels[source] ?? source : "Desconocida"}
+            </span>
+            {lastUpdated ? (
+              <span className="calculator__price-updated">
+                Última actualización: {new Date(lastUpdated).toLocaleTimeString("es-ES", {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </span>
+            ) : null}
+          </>
+        )}
+      </div>
+
+      {aggregateErrors.length > 0 && (
+        <div className="calculator__errors" role="alert">
+          <h3>Revisa estos campos:</h3>
+          <ul>
+            {aggregateErrors.map((message, index) => (
+              <li key={`${message}-${index}`}>{message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <form className="calculator__form" onSubmit={(event) => event.preventDefault()}>
         <div className="field">
           <label htmlFor="date">Fecha final</label>
           <input
@@ -103,12 +253,33 @@ export function Calculator() {
             type="date"
             value={selectedDate}
             onChange={handleDateChange}
+            aria-describedby={dateError ? "date-error" : "date-help"}
           />
           {dateError ? (
-            <p className="error">{dateError}</p>
+            <p id="date-error" className="error">
+              {dateError}
+            </p>
           ) : (
-            <p className="help">Selecciona la fecha final</p>
+            <p id="date-help" className="help">
+              Selecciona la fecha límite para agotar tus BTC retirables.
+            </p>
           )}
+        </div>
+
+        <div className="field">
+          <label htmlFor="frequency">Frecuencia de retiro</label>
+          <select
+            id="frequency"
+            value={frequency}
+            onChange={handleFrequencyChange}
+            aria-describedby="frequency-help"
+          >
+            <option value="monthly">Mensual</option>
+            <option value="weekly">Semanal</option>
+          </select>
+          <p id="frequency-help" className="help">
+            Calcularemos el monto {periodLabel} que puedes retirar.
+          </p>
         </div>
 
         <div className="field">
@@ -118,38 +289,121 @@ export function Calculator() {
             type="number"
             value={walletValue}
             onChange={handleWalletChange}
+            aria-describedby={walletError ? "wallet-error" : "wallet-help"}
+            min="0"
+            step="0.00000001"
           />
           {walletError ? (
-            <p className="error">{walletError}</p>
+            <p id="wallet-error" className="error">
+              {walletError}
+            </p>
           ) : (
-            <p className="help">Total de BTC en la wallet</p>
+            <p id="wallet-help" className="help">
+              Total de BTC disponibles en tu cartera.
+            </p>
           )}
         </div>
 
         <div className="field">
-          <label htmlFor="btc">BTC Intocable</label>
+          <label htmlFor="btc">BTC intocable</label>
           <input
             id="btc"
             type="number"
             value={btcIntocableValue}
             onChange={handleBtcIntocableChange}
+            aria-describedby={btcError ? "btc-error" : "btc-help"}
+            min="0"
+            step="0.00000001"
           />
           {btcError ? (
-            <p className="error">{btcError}</p>
+            <p id="btc-error" className="error">
+              {btcError}
+            </p>
           ) : (
-            <p className="help">Cantidad de BTC que no se puede retirar</p>
+            <p id="btc-help" className="help">
+              Cantidad de BTC que prefieres mantener intacta.
+            </p>
           )}
         </div>
 
-        <div className="field">
-          <p>BTC mensual para retirar: {totalBTCValue}</p>
-        </div>
-
-        <div className="field">
-          <p>
-            Valor total de EUR: {(totalBTCValue * (btcPrice ?? 0)).toFixed(2)}
-          </p>
+        <div className="calculator__result">
+          <h3>{`Retiro ${periodLabel}`}</h3>
+          <p className="calculator__result-value">{btcFormatter.format(totalBTCValue)} BTC</p>
+          <p className="calculator__result-eur">{eurFormatter.format(totalEURValue)}</p>
         </div>
       </form>
-    );
+
+      <section className="calculator__profiles" aria-labelledby="profiles-heading">
+        <div className="calculator__profiles-header">
+          <h3 id="profiles-heading">Escenarios guardados</h3>
+          <p className="help">
+            Guarda hasta cinco configuraciones distintas para compararlas más tarde.
+          </p>
+        </div>
+        <form className="calculator__profile-form" onSubmit={handleProfileSave}>
+          <label className="visualmente-oculto" htmlFor="profile-name">
+            Nombre del escenario
+          </label>
+          <input
+            id="profile-name"
+            type="text"
+            value={profileName}
+            onChange={(event) => setProfileName(event.target.value)}
+            placeholder="Ej. Estrategia conservadora"
+          />
+          <button type="submit" className="primary-button">
+            Guardar escenario
+          </button>
+        </form>
+
+        {profiles.length === 0 ? (
+          <p className="help">Aún no tienes escenarios guardados.</p>
+        ) : (
+          <ul className="calculator__profiles-list">
+            {profiles.map((profile) => (
+              <li key={profile.id} className="calculator__profile-item">
+                <div>
+                  <h4>{profile.name}</h4>
+                  <dl>
+                    <div>
+                      <dt>Wallet</dt>
+                      <dd>{btcFormatter.format(profile.walletValue)} BTC</dd>
+                    </div>
+                    <div>
+                      <dt>Intocable</dt>
+                      <dd>{btcFormatter.format(profile.btcIntocableValue)} BTC</dd>
+                    </div>
+                    <div>
+                      <dt>Finaliza</dt>
+                      <dd>{profile.selectedDate || "Sin fecha"}</dd>
+                    </div>
+                    <div>
+                      <dt>Frecuencia</dt>
+                      <dd>{profile.frequency === "weekly" ? "Semanal" : "Mensual"}</dd>
+                    </div>
+                  </dl>
+                </div>
+                <div className="calculator__profile-actions">
+                  <button
+                    type="button"
+                    className="secondary-button"
+                    onClick={() => handleProfileLoad(profile)}
+                  >
+                    Cargar
+                  </button>
+                  <button
+                    type="button"
+                    className="ghost-button"
+                    onClick={() => handleProfileDelete(profile.id)}
+                  >
+                    Eliminar
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
 }

--- a/src/components/Dashboard/Dashboard.css
+++ b/src/components/Dashboard/Dashboard.css
@@ -1,0 +1,82 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.dashboard__avatar {
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+.dashboard__subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--muted-foreground);
+}
+
+.dashboard__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.dashboard__metrics div {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0.9rem;
+  padding: 0.75rem 1rem;
+}
+
+.dashboard__metrics dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+  margin: 0 0 0.35rem;
+}
+
+.dashboard__metrics dd {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.dashboard__positive {
+  color: #24d37a;
+}
+
+.dashboard__negative {
+  color: #ff5f5f;
+}
+
+.dashboard__chart {
+  height: 280px;
+}
+
+.dashboard__empty {
+  margin: 0;
+  color: var(--muted-foreground);
+  text-align: center;
+  padding: 2rem 0;
+}
+
+.dashboard__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.dashboard__tooltip-label {
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .dashboard__footer {
+    justify-content: center;
+  }
+}

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -1,45 +1,143 @@
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
+import './Dashboard.css';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 
-// Dataset ficticio de ganancias y pérdidas mensuales
-const data = [
-  { month: "Ene", value: 400 },
-  { month: "Feb", value: -200 },
-  { month: "Mar", value: 1000 },
-  { month: "Abr", value: -800 },
-  { month: "May", value: 650 },
-];
+const SOURCE_LABELS = {
+  coindesk: 'CoinDesk',
+  coingecko: 'CoinGecko',
+  binance: 'Binance',
+};
 
-// Subcomponente que muestra un gráfico de barras de ganancias/pérdidas
-function ProfitLossChart() {
+const currencyFormatter = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 2,
+});
+
+const numberFormatter = new Intl.NumberFormat('es-ES', {
+  maximumFractionDigits: 2,
+});
+
+const tooltipFormatter = value => currencyFormatter.format(value);
+
+export function Dashboard({
+  username = 'Guest',
+  avatarUrl = 'https://i.pravatar.cc/100',
+  history,
+  rawHistory = [],
+  price,
+  source,
+  lastUpdated,
+  onClearHistory,
+}) {
+  const hasHistory = Array.isArray(history) && history.length > 0;
+  const safeRawHistory = Array.isArray(rawHistory) ? rawHistory : [];
+  const latestEntry = hasHistory ? safeRawHistory.at(-1) : null;
+  const firstEntry = hasHistory ? safeRawHistory[0] : null;
+  const variation =
+    hasHistory && safeRawHistory.length > 1 && firstEntry?.price && latestEntry?.price
+      ? ((latestEntry.price - firstEntry.price) / firstEntry.price) * 100
+      : 0;
+
+  const formattedVariation = `${variation >= 0 ? '+' : ''}${numberFormatter.format(
+    variation
+  )}%`;
+
   return (
-    <ResponsiveContainer width="100%" height={300}>
-      <BarChart data={data}>
-        <defs>
-          <linearGradient id="profitGradient" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor="#646cff" />
-            <stop offset="100%" stopColor="#42a5f5" />
-          </linearGradient>
-        </defs>
-        <CartesianGrid strokeDasharray="3 3" vertical={false} />
-        <XAxis dataKey="month" axisLine={false} tickLine={false} />
-        <YAxis allowDecimals={false} axisLine={false} tickLine={false} />
-        <Tooltip />
-        <Bar dataKey="value" fill="url(#profitGradient)" />
-      </BarChart>
-    </ResponsiveContainer>
-  );
-}
-
-export function Dashboard({ username = "Guest", avatarUrl = "https://i.pravatar.cc/100" }) {
-  return (
-    <section>
-      <header>
-        <img src={avatarUrl} alt={`${username} avatar`} width="50" height="50" />
-        <h2>{username}</h2>
+    <section className="dashboard card" aria-labelledby="dashboard-heading">
+      <header className="dashboard__header">
+        <img
+          src={avatarUrl}
+          alt={`${username} avatar`}
+          width="56"
+          height="56"
+          className="dashboard__avatar"
+        />
+        <div>
+          <h2 id="dashboard-heading">Hola, {username}</h2>
+          <p className="dashboard__subtitle">
+            Sigue la evolución del precio y tus escenarios guardados.
+          </p>
+        </div>
       </header>
-      <h3>Profit &amp; Loss</h3>
-      <ProfitLossChart />
+
+      <dl className="dashboard__metrics">
+        <div>
+          <dt>Precio actual</dt>
+          <dd>{price ? currencyFormatter.format(price) : 'Sin datos'}</dd>
+        </div>
+        <div>
+          <dt>Proveedor</dt>
+          <dd>{source ? SOURCE_LABELS[source] ?? source : 'Sin datos'}</dd>
+        </div>
+        <div>
+          <dt>Actualizado</dt>
+          <dd>
+            {lastUpdated
+              ? new Date(lastUpdated).toLocaleTimeString('es-ES', {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })
+              : 'Sin datos'}
+          </dd>
+        </div>
+        <div>
+          <dt>Tendencia</dt>
+          <dd
+            className={
+              hasHistory && safeRawHistory.length > 1
+                ? variation >= 0
+                  ? 'dashboard__positive'
+                  : 'dashboard__negative'
+                : undefined
+            }
+          >
+            {hasHistory && safeRawHistory.length > 1 ? formattedVariation : 'Sin historial'}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="dashboard__chart" role="img" aria-label="Histórico del precio en euros">
+        {hasHistory ? (
+          <ResponsiveContainer width="100%" height={280}>
+            <AreaChart data={history} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+              <defs>
+                <linearGradient id="priceGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#f7931a" stopOpacity={0.9} />
+                  <stop offset="100%" stopColor="#f7931a" stopOpacity={0.1} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="time" axisLine={false} tickLine={false} />
+              <YAxis
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={value => currencyFormatter.format(value)}
+                width={90}
+              />
+              <Tooltip formatter={tooltipFormatter} labelClassName="dashboard__tooltip-label" />
+              <Area type="monotone" dataKey="price" stroke="#f7931a" fill="url(#priceGradient)" />
+            </AreaChart>
+          </ResponsiveContainer>
+        ) : (
+          <p className="dashboard__empty">
+            El historial se completará automáticamente cuando obtengamos el precio de BTC.
+          </p>
+        )}
+      </div>
+
+      <footer className="dashboard__footer">
+        <button type="button" onClick={onClearHistory} className="secondary-button">
+          Limpiar historial
+        </button>
+      </footer>
     </section>
   );
 }
-

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,26 +1,67 @@
 .header {
-    position: fixed;
-    top: 0;
-    left: 0;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: linear-gradient(135deg, rgba(8, 16, 32, 0.9), rgba(20, 28, 48, 0.8));
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+}
+
+.header__inner {
+  margin: 0 auto;
+  max-width: 1200px;
+  padding: 1rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.header__brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header__brand h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.header__brand p {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--muted-foreground);
+}
+
+.header__actions {
+  display: flex;
+  gap: 1rem;
+}
+
+.header__actions a {
+  color: inherit;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.header__actions a:hover,
+.header__actions a:focus {
+  background: rgba(255, 255, 255, 0.12);
+  outline: none;
+}
+
+@media (max-width: 768px) {
+  .header__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header__actions {
     width: 100%;
-    background-color: #bddded;
-    padding: 10px 20px;
-    display: flex;
-    align-items: center;
-    justify-content:space-around;
-    box-shadow: 0px 10px 10px rgba(0, 0, 0, 0.5);
-    margin-bottom: 30px;
-    
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
-  
-  
-  
-  @media screen and (max-width: 768px) {
-    .header {
-      padding: 10px;
-    }
-  
-    .header h1 {
-      font-size: 18px; /* Reduce el tamaño del texto en dispositivos más pequeños */
-    }
-  }
+}

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,13 +1,27 @@
 import './Header.css';
-import {Image} from '../Image/Image';
-const Header = () => {
+import { Image } from '../Image/Image';
 
-return (
+const Header = () => {
+  return (
     <header className="header">
-        <Image src="https://seeklogo.com/images/W/wrapped-bitcoin-wbtc-logo-A3917F45C9-seeklogo.com.png" alt="Bitcoin"/>
-        <h1>Calculadora de BTC</h1>
+      <div className="header__inner">
+        <div className="header__brand">
+          <Image
+            src="https://seeklogo.com/images/W/wrapped-bitcoin-wbtc-logo-A3917F45C9-seeklogo.com.png"
+            alt="Bitcoin"
+          />
+          <div>
+            <h1>Calculadora de BTC</h1>
+            <p>Diseña tu estrategia de retiro con datos en tiempo real.</p>
+          </div>
+        </div>
+        <nav className="header__actions" aria-label="Acciones rápidas">
+          <a href="#calculator-heading">Calculadora</a>
+          <a href="#dashboard-heading">Dashboard</a>
+        </nav>
+      </div>
     </header>
-    );
+  );
 };
 
 export default Header;

--- a/src/components/Image/Image.css
+++ b/src/components/Image/Image.css
@@ -1,4 +1,5 @@
 .image {
-    width: 100px; /* Ajusta el tamaño del logo según sea necesario */
-    height: auto; /* Permite que la altura se ajuste automáticamente */
-  }
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+}

--- a/src/hooks/btc.js
+++ b/src/hooks/btc.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 
 /**
  * @typedef {Object} BTCState
@@ -6,30 +6,41 @@ import { useState, useEffect, useRef } from 'react';
  * @property {'coindesk' | 'coingecko' | 'binance' | null} source
  * @property {boolean} loading
  * @property {string | null} error
+ * @property {string | null} lastUpdated ISO string when the price was refreshed
  */
 
 /**
  * Hook to obtain the Bitcoin price from multiple providers.
  * @param {number} [refreshMs=60000]
- * @returns {BTCState}
+ * @returns {BTCState & { refresh: () => Promise<void> }}
  */
 export function UseBTCPrice(refreshMs = 60000) {
   const [state, setState] = useState(
-    /** @type {BTCState} */ ({ price: null, source: null, loading: true, error: null })
+    /** @type {BTCState} */ ({
+      price: null,
+      source: null,
+      loading: true,
+      error: null,
+      lastUpdated: null,
+    })
   );
   const timer = useRef(/** @type {number | null} */ (null));
+  const controllerRef = useRef(/** @type {AbortController | null} */ (null));
 
-  useEffect(() => {
+  const fetchWithFallback = useCallback(async () => {
+    if (controllerRef.current) {
+      controllerRef.current.abort();
+    }
+
     const controller = new AbortController();
+    controllerRef.current = controller;
 
     const fetchCoindesk = async () => {
-      // Endpoint correcto: incluye EUR dentro de currentprice.json
       const res = await fetch('https://api.coindesk.com/v1/bpi/currentprice.json', {
         signal: controller.signal,
       });
       if (!res.ok) throw new Error(`Coindesk ${res.status}`);
       const data = await res.json();
-      // Estructura: data.bpi.EUR.rate_float
       const price = Number(data?.bpi?.EUR?.rate_float);
       if (!Number.isFinite(price)) throw new Error('Coindesk sin EUR válido');
       return { price, source: 'coindesk' };
@@ -48,10 +59,9 @@ export function UseBTCPrice(refreshMs = 60000) {
     };
 
     const fetchBinance = async () => {
-      const res = await fetch(
-        'https://api.binance.com/api/v3/ticker/price?symbol=BTCEUR',
-        { signal: controller.signal }
-      );
+      const res = await fetch('https://api.binance.com/api/v3/ticker/price?symbol=BTCEUR', {
+        signal: controller.signal,
+      });
       if (!res.ok) throw new Error(`Binance ${res.status}`);
       const data = await res.json();
       const price = Number(data?.price);
@@ -59,53 +69,72 @@ export function UseBTCPrice(refreshMs = 60000) {
       return { price, source: 'binance' };
     };
 
-    const getPrice = async () => {
-      setState(s => ({ ...s, loading: true, error: null }));
+    setState(s => ({ ...s, loading: true, error: null }));
 
-      try {
-        const r1 = await fetchCoindesk();
-        setState({ price: r1.price, source: r1.source, loading: false, error: null });
-        return;
-      } catch (e1) {
-        // continúa
-      }
+    try {
+      const r1 = await fetchCoindesk();
+      setState({
+        price: r1.price,
+        source: r1.source,
+        loading: false,
+        error: null,
+        lastUpdated: new Date().toISOString(),
+      });
+      return;
+    } catch (error) {
+      // continúa
+    }
 
-      try {
-        const r2 = await fetchCoingecko();
-        setState({ price: r2.price, source: r2.source, loading: false, error: null });
-        return;
-      } catch (e2) {
-        // continúa
-      }
+    try {
+      const r2 = await fetchCoingecko();
+      setState({
+        price: r2.price,
+        source: r2.source,
+        loading: false,
+        error: null,
+        lastUpdated: new Date().toISOString(),
+      });
+      return;
+    } catch (error) {
+      // continúa
+    }
 
-      try {
-        const r3 = await fetchBinance();
-        setState({ price: r3.price, source: r3.source, loading: false, error: null });
-        return;
-      } catch (e3) {
-        setState(s => ({
-          ...s,
-          loading: false,
-          error: 'No se pudo obtener el precio (Coindesk/Coingecko/Binance fallaron)',
-        }));
-      }
-    };
+    try {
+      const r3 = await fetchBinance();
+      setState({
+        price: r3.price,
+        source: r3.source,
+        loading: false,
+        error: null,
+        lastUpdated: new Date().toISOString(),
+      });
+      return;
+    } catch (error) {
+      setState(s => ({
+        ...s,
+        loading: false,
+        error: 'No se pudo obtener el precio (Coindesk/Coingecko/Binance fallaron)',
+      }));
+    }
+  }, []);
 
-    getPrice();
+  useEffect(() => {
+    fetchWithFallback();
 
-    // refresco periódico
     if (refreshMs > 0) {
-      timer.current = window.setInterval(getPrice, refreshMs);
+      timer.current = window.setInterval(fetchWithFallback, refreshMs);
     }
 
     return () => {
-      controller.abort();
+      if (controllerRef.current) {
+        controllerRef.current.abort();
+      }
       if (timer.current) {
         clearInterval(timer.current);
         timer.current = null;
       }
     };
-  }, [refreshMs]);
+  }, [fetchWithFallback, refreshMs]);
 
-  return state; // { price, source, loading, error }
+  return { ...state, refresh: fetchWithFallback };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,45 @@
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  color-scheme: dark;
+  --background: radial-gradient(circle at 20% 20%, #1b2735, #090a0f);
+  --foreground: #f5f5f5;
+  --muted-foreground: rgba(245, 245, 245, 0.65);
+  --text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 a {
   font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: inherit;
+  text-decoration: none;
 }
+
 a:hover {
-  color: #535bf2;
+  text-decoration: underline;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background: var(--background);
+  color: var(--foreground);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+h1,
+ h2,
+ h3,
+ h4,
+ h5,
+ h6 {
+  text-shadow: var(--text-shadow);
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+* {
+  box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- modernize the shell with a sticky gradient header, glassmorphism cards and a responsive grid layout
- upgrade the BTC calculator with manual price refresh, frequency controls, localized formatting and saved scenario profiles in localStorage
- surface realtime price provenance, last refresh timestamps and a stored history chart in the dashboard with clearing controls

## Testing
- `npm run test`
- `npm run lint` *(fails: missing eslint-plugin-react because npm install is blocked by registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d38033fd448323b8a976cf386f6245