### PR TITLE
Improve BTC planner design and add UI insights

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,42 +5,87 @@
 }
 
 .app-shell {
+  position: relative;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   color: var(--foreground);
+  isolation: isolate;
+}
+
+.app-shell::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(247, 147, 26, 0.18), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(87, 124, 255, 0.16), transparent 55%),
+    radial-gradient(circle at 50% 80%, rgba(16, 227, 178, 0.12), transparent 60%);
+  opacity: 0.85;
+  pointer-events: none;
 }
 
 .content-grid {
+  position: relative;
   width: min(1200px, calc(100% - 3rem));
   margin: 0 auto;
-  padding: 2rem 0 4rem;
+  padding: 2.5rem 0 4.5rem;
   display: grid;
-  gap: 2rem;
+  gap: 2.5rem;
+}
+
+.content-grid::before {
+  content: '';
+  position: absolute;
+  inset: 1rem;
+  border-radius: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: linear-gradient(145deg, rgba(11, 16, 32, 0.6), rgba(8, 12, 24, 0.45));
+  z-index: -1;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
 }
 
 .card {
-  border-radius: 1.5rem;
-  padding: 2rem;
+  position: relative;
+  border-radius: 1.6rem;
+  padding: 2.2rem;
   background: rgba(10, 14, 26, 0.65);
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(14px);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+  pointer-events: none;
+}
+
+.card > * {
+  position: relative;
+  z-index: 1;
 }
 
 .primary-button,
 .secondary-button,
 .ghost-button {
   border-radius: 999px;
-  padding: 0.5rem 1.25rem;
+  padding: 0.55rem 1.35rem;
   border: none;
   cursor: pointer;
   font-weight: 600;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
 }
 
 .primary-button {
   background: linear-gradient(135deg, #f7931a, #ffb347);
   color: #1c1c1c;
+  box-shadow: 0 12px 25px rgba(247, 147, 26, 0.3);
 }
 
 .secondary-button {
@@ -57,7 +102,8 @@
 .secondary-button:hover,
 .ghost-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.12);
+  filter: brightness(1.05);
 }
 
 .primary-button:focus,
@@ -65,6 +111,15 @@
 .ghost-button:focus {
   outline: 2px solid rgba(247, 147, 26, 0.6);
   outline-offset: 2px;
+}
+
+.primary-button:disabled,
+.secondary-button:disabled,
+.ghost-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
 @media (min-width: 1024px) {
@@ -77,9 +132,22 @@
 @media (max-width: 600px) {
   .content-grid {
     width: calc(100% - 2rem);
+    padding: 2rem 0 3.5rem;
+  }
+
+  .content-grid::before {
+    inset: 0.5rem;
   }
 
   .card {
-    padding: 1.5rem;
+    padding: 1.6rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .primary-button,
+  .secondary-button,
+  .ghost-button {
+    transition: none;
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,7 +70,14 @@ function App() {
 
   return (
     <div className="app-shell">
-      <Header />
+      <Header
+        price={price}
+        source={source}
+        loading={loading}
+        error={error}
+        lastUpdated={lastUpdated}
+        onRefresh={refresh}
+      />
       <main className="content-grid">
         <Calculator
           price={price}

--- a/src/components/Calculator/Calculator.css
+++ b/src/components/Calculator/Calculator.css
@@ -1,7 +1,7 @@
 .calculator {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .calculator__header {
@@ -19,14 +19,15 @@
 .calculator__price {
   display: grid;
   gap: 0.35rem;
-  padding: 1rem;
-  border-radius: 1rem;
+  padding: 1.25rem;
+  border-radius: 1.1rem;
   background: rgba(255, 255, 255, 0.04);
   font-weight: 600;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
 .calculator__price-value {
-  font-size: 1.5rem;
+  font-size: 1.6rem;
 }
 
 .calculator__price-source,
@@ -37,10 +38,11 @@
 }
 
 .calculator__errors {
-  border: 1px solid #ff5f5f;
-  border-radius: 0.8rem;
-  padding: 1rem;
+  border: 1px solid rgba(255, 95, 95, 0.6);
+  border-radius: 0.95rem;
+  padding: 1rem 1.25rem;
   background: rgba(255, 95, 95, 0.1);
+  box-shadow: 0 12px 24px rgba(255, 95, 95, 0.12);
 }
 
 .calculator__errors h3 {
@@ -55,24 +57,34 @@
 
 .calculator__form {
   display: grid;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.5rem;
+}
+
+.field label {
+  font-weight: 600;
 }
 
 .field input,
 .field select,
 .calculator__profile-form input {
   width: 100%;
-  padding: 0.6rem 0.75rem;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(255, 255, 255, 0.02);
   color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input::placeholder,
+.calculator__profile-form input::placeholder {
+  color: rgba(255, 255, 255, 0.45);
 }
 
 .field input:focus,
@@ -80,6 +92,7 @@
 .calculator__profile-form input:focus {
   outline: 2px solid rgba(247, 147, 26, 0.6);
   border-color: transparent;
+  box-shadow: 0 0 0 4px rgba(247, 147, 26, 0.15);
 }
 
 .error {
@@ -96,11 +109,12 @@
 
 .calculator__result {
   display: grid;
-  gap: 0.25rem;
+  gap: 0.35rem;
   text-align: center;
-  padding: 1.5rem;
-  border-radius: 1rem;
-  background: linear-gradient(135deg, rgba(247, 147, 26, 0.15), rgba(247, 147, 26, 0.05));
+  padding: 1.75rem;
+  border-radius: 1.1rem;
+  background: linear-gradient(135deg, rgba(247, 147, 26, 0.2), rgba(247, 147, 26, 0.05));
+  box-shadow: inset 0 0 0 1px rgba(247, 147, 26, 0.25);
 }
 
 .calculator__result h3 {
@@ -112,7 +126,7 @@
 }
 
 .calculator__result-value {
-  font-size: 2rem;
+  font-size: 2.1rem;
   margin: 0;
   font-weight: 700;
 }
@@ -121,6 +135,84 @@
   margin: 0;
   font-size: 1.1rem;
   color: var(--muted-foreground);
+}
+
+.calculator__insights {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.calculator__progress {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.calculator__progress-bar {
+  display: flex;
+  align-items: stretch;
+  height: 0.8rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.calculator__progress-segment {
+  display: block;
+  height: 100%;
+  transition: flex-basis 0.4s ease, flex-grow 0.4s ease;
+}
+
+.calculator__progress-segment--withdrawable {
+  background: linear-gradient(90deg, #f7931a, #ffb347);
+}
+
+.calculator__progress-segment--protected {
+  background: linear-gradient(90deg, rgba(138, 92, 246, 0.95), rgba(93, 139, 255, 0.85));
+}
+
+.calculator__progress-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.calculator__progress-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.calculator__progress-chip--withdrawable::before,
+.calculator__progress-chip--protected::before {
+  content: '';
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.calculator__progress-chip--withdrawable::before {
+  background: linear-gradient(135deg, #f7931a, #ffb347);
+}
+
+.calculator__progress-chip--protected::before {
+  background: linear-gradient(135deg, rgba(138, 92, 246, 0.95), rgba(93, 139, 255, 0.85));
+}
+
+.calculator__insights-note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(245, 245, 245, 0.75);
 }
 
 .calculator__profiles {
@@ -154,9 +246,10 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  padding: 1rem;
+  padding: 1.1rem;
   border-radius: 1rem;
   background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
 .calculator__profile-item h4 {
@@ -197,6 +290,18 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+@media (min-width: 900px) {
+  .calculator__form {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .calculator__result,
+  .calculator__insights {
+    grid-column: 1 / -1;
+  }
 }
 
 @media (max-width: 768px) {

--- a/src/components/Calculator/Calculator.jsx
+++ b/src/components/Calculator/Calculator.jsx
@@ -161,6 +161,14 @@ export function Calculator({ price, source, loading, error, lastUpdated, onRefre
   };
   const totalBTCValue = calculateTotalBTCValue();
   const totalEURValue = price ? totalBTCValue * price : 0;
+  const safeWalletValue = walletValue > 0 ? walletValue : 0;
+  const safeProtectedValue = Math.max(btcIntocableValue, 0);
+  const withdrawable = Math.max(safeWalletValue - safeProtectedValue, 0);
+  const preserved = Math.min(safeProtectedValue, safeWalletValue);
+  const withdrawablePercent = safeWalletValue > 0 ? (withdrawable / safeWalletValue) * 100 : 0;
+  const preservedPercent = safeWalletValue > 0 ? (preserved / safeWalletValue) * 100 : 0;
+  const withdrawablePercentLabel = Math.round(withdrawablePercent);
+  const preservedPercentLabel = Math.round(preservedPercent);
 
   const aggregateErrors = useMemo(() => {
     const unique = new Set(
@@ -330,6 +338,45 @@ export function Calculator({ price, source, loading, error, lastUpdated, onRefre
           <h3>{`Retiro ${periodLabel}`}</h3>
           <p className="calculator__result-value">{btcFormatter.format(totalBTCValue)} BTC</p>
           <p className="calculator__result-eur">{eurFormatter.format(totalEURValue)}</p>
+        </div>
+
+        <div className="calculator__insights">
+          <div
+            className="calculator__progress"
+            role="group"
+            aria-label="Distribución actual de tu cartera"
+          >
+            <div
+              className="calculator__progress-bar"
+              role="progressbar"
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={withdrawablePercentLabel}
+              aria-valuetext={`Puedes retirar ${btcFormatter.format(withdrawable)} BTC, que representan el ${withdrawablePercentLabel}% de tu cartera.`}
+            >
+              <span
+                className="calculator__progress-segment calculator__progress-segment--withdrawable"
+                style={{ flexBasis: `${withdrawablePercent}%`, flexGrow: withdrawablePercent }}
+              />
+              <span
+                className="calculator__progress-segment calculator__progress-segment--protected"
+                style={{ flexBasis: `${preservedPercent}%`, flexGrow: preservedPercent }}
+              />
+            </div>
+            <div className="calculator__progress-legend">
+              <span className="calculator__progress-chip calculator__progress-chip--withdrawable">
+                Retirable: {btcFormatter.format(withdrawable)} BTC ({withdrawablePercentLabel}%)
+              </span>
+              <span className="calculator__progress-chip calculator__progress-chip--protected">
+                Resguardo: {btcFormatter.format(preserved)} BTC ({preservedPercentLabel}%)
+              </span>
+            </div>
+          </div>
+          <p className="calculator__insights-note">
+            {withdrawable > 0
+              ? `Tu estrategia libera ${btcFormatter.format(withdrawable)} BTC para retiros escalonados.`
+              : 'Ajusta los valores para liberar BTC retirables y visualizar un plan de retiros.'}
+          </p>
         </div>
       </form>
 

--- a/src/components/Dashboard/Dashboard.css
+++ b/src/components/Dashboard/Dashboard.css
@@ -1,7 +1,7 @@
 .dashboard {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .dashboard__header {
@@ -13,6 +13,7 @@
 .dashboard__avatar {
   border-radius: 50%;
   border: 2px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.3);
 }
 
 .dashboard__subtitle {
@@ -22,15 +23,16 @@
 
 .dashboard__metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1.1rem;
   margin: 0;
 }
 
 .dashboard__metrics div {
   background: rgba(255, 255, 255, 0.04);
-  border-radius: 0.9rem;
-  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  padding: 0.85rem 1.1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
 .dashboard__metrics dt {
@@ -43,7 +45,7 @@
 
 .dashboard__metrics dd {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.15rem;
   font-weight: 600;
 }
 
@@ -57,6 +59,10 @@
 
 .dashboard__chart {
   height: 280px;
+  padding: 1.1rem;
+  border-radius: 1.1rem;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
 .dashboard__empty {
@@ -64,6 +70,60 @@
   color: var(--muted-foreground);
   text-align: center;
   padding: 2rem 0;
+}
+
+.dashboard__recent {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dashboard__recent h3 {
+  margin: 0;
+}
+
+.dashboard__recent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.dashboard__recent-item {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, auto)) 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.dashboard__recent-time {
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+}
+
+.dashboard__recent-value {
+  font-weight: 600;
+}
+
+.dashboard__chip {
+  justify-self: flex-end;
+  font-size: 0.8rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.dashboard__chip--positive {
+  color: #1ddf82;
+}
+
+.dashboard__chip--negative {
+  color: #ff7878;
 }
 
 .dashboard__footer {
@@ -78,5 +138,13 @@
 @media (max-width: 768px) {
   .dashboard__footer {
     justify-content: center;
+  }
+
+  .dashboard__recent-item {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dashboard__chip {
+    justify-self: start;
   }
 }

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -49,6 +49,7 @@ export function Dashboard({
   const formattedVariation = `${variation >= 0 ? '+' : ''}${numberFormatter.format(
     variation
   )}%`;
+  const recentHistory = hasHistory ? [...safeRawHistory].slice(-4).reverse() : [];
 
   return (
     <section className="dashboard card" aria-labelledby="dashboard-heading">
@@ -122,7 +123,17 @@ export function Dashboard({
                 tickFormatter={value => currencyFormatter.format(value)}
                 width={90}
               />
-              <Tooltip formatter={tooltipFormatter} labelClassName="dashboard__tooltip-label" />
+              <Tooltip
+                formatter={tooltipFormatter}
+                labelClassName="dashboard__tooltip-label"
+                contentStyle={{
+                  background: 'rgba(9, 12, 24, 0.85)',
+                  borderRadius: '0.75rem',
+                  border: '1px solid rgba(255, 255, 255, 0.1)',
+                  boxShadow: '0 18px 28px rgba(0, 0, 0, 0.35)',
+                  color: '#f5f5f5',
+                }}
+              />
               <Area type="monotone" dataKey="price" stroke="#f7931a" fill="url(#priceGradient)" />
             </AreaChart>
           </ResponsiveContainer>
@@ -132,6 +143,37 @@ export function Dashboard({
           </p>
         )}
       </div>
+
+      {recentHistory.length > 0 ? (
+        <section className="dashboard__recent" aria-label="Últimas capturas del precio">
+          <h3>Últimos movimientos</h3>
+          <ul className="dashboard__recent-list">
+            {recentHistory.map((entry, index) => {
+              const previous = recentHistory[index + 1];
+              const diff = previous?.price ? entry.price - previous.price : 0;
+              const diffFormatted = numberFormatter.format(Math.abs(diff));
+              const diffLabel = `${diff >= 0 ? '+' : '-'}${diffFormatted}`;
+              const diffClass =
+                diff === 0 ? '' : diff > 0 ? 'dashboard__chip--positive' : 'dashboard__chip--negative';
+              const chipContent = previous
+                ? diff === 0
+                  ? 'Sin cambio'
+                  : `${diffLabel} EUR`
+                : 'Dato inicial';
+
+              return (
+                <li key={entry.time} className="dashboard__recent-item">
+                  <span className="dashboard__recent-time">
+                    {new Date(entry.time).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                  <span className="dashboard__recent-value">{currencyFormatter.format(entry.price)}</span>
+                  <span className={`dashboard__chip ${diffClass}`}>{chipContent}</span>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
 
       <footer className="dashboard__footer">
         <button type="button" onClick={onClearHistory} className="secondary-button">

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -2,12 +2,25 @@
   position: sticky;
   top: 0;
   z-index: 10;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(14px);
   background: linear-gradient(135deg, rgba(8, 16, 32, 0.9), rgba(20, 28, 48, 0.8));
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+}
+
+.header::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 15% 120%, rgba(247, 147, 26, 0.22), transparent 55%),
+    radial-gradient(circle at 85% -60%, rgba(77, 106, 255, 0.18), transparent 45%);
+  opacity: 0.9;
 }
 
 .header__inner {
+  position: relative;
   margin: 0 auto;
   max-width: 1200px;
   padding: 1rem 1.5rem;
@@ -15,6 +28,7 @@
   justify-content: space-between;
   align-items: center;
   gap: 1.5rem;
+  flex-wrap: wrap;
 }
 
 .header__brand {
@@ -25,43 +39,135 @@
 
 .header__brand h1 {
   margin: 0;
-  font-size: 1.6rem;
+  font-size: 1.65rem;
 }
 
 .header__brand p {
   margin: 0.25rem 0 0;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   color: var(--muted-foreground);
+}
+
+.header__meta {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
 }
 
 .header__actions {
   display: flex;
-  gap: 1rem;
+  gap: 0.75rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
 
 .header__actions a {
   color: inherit;
   font-weight: 600;
-  padding: 0.4rem 0.75rem;
+  padding: 0.4rem 0.85rem;
   border-radius: 999px;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .header__actions a:hover,
 .header__actions a:focus {
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(247, 147, 26, 0.2);
+  color: #fff4e2;
   outline: none;
 }
 
-@media (max-width: 768px) {
+.header__status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.header__badge {
+  min-width: 220px;
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.9rem;
+  background: rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.header__badge--loading {
+  background: linear-gradient(135deg, rgba(247, 147, 26, 0.2), rgba(247, 147, 26, 0.05));
+  box-shadow: inset 0 0 0 1px rgba(247, 147, 26, 0.3);
+}
+
+.header__badge--error {
+  background: linear-gradient(135deg, rgba(255, 95, 95, 0.22), rgba(255, 95, 95, 0.08));
+  box-shadow: inset 0 0 0 1px rgba(255, 95, 95, 0.35);
+}
+
+.header__badge--error .header__badge-label {
+  color: #ffd2d2;
+}
+
+.header__badge--error .header__badge-source,
+.header__badge--error .header__badge-time {
+  color: rgba(255, 210, 210, 0.75);
+}
+
+.header__badge-label {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.header__badge-source,
+.header__badge-time {
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+}
+
+.header__refresh {
+  padding-inline: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.header__refresh:hover,
+.header__refresh:focus {
+  background: rgba(247, 147, 26, 0.15);
+  box-shadow: inset 0 0 0 1px rgba(247, 147, 26, 0.4);
+}
+
+.header__refresh:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+@media (max-width: 900px) {
+  .header__meta {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .header__status {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 640px) {
   .header__inner {
-    flex-direction: column;
     align-items: flex-start;
   }
 
-  .header__actions {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
+  .header__meta {
+    gap: 1rem;
+  }
+
+  .header__status {
+    flex-direction: column;
+    align-items: stretch;
   }
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,7 +1,31 @@
 import './Header.css';
 import { Image } from '../Image/Image';
 
-const Header = () => {
+const SOURCE_LABELS = {
+  coindesk: 'CoinDesk',
+  coingecko: 'CoinGecko',
+  binance: 'Binance',
+};
+
+const priceFormatter = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 2,
+});
+
+const Header = ({ price, source, lastUpdated, loading, error, onRefresh }) => {
+  const formattedPrice =
+    price && Number.isFinite(price) ? priceFormatter.format(price) : 'Sin datos';
+  const sourceLabel = source ? SOURCE_LABELS[source] ?? source : 'Proveedor desconocido';
+  const updatedLabel =
+    lastUpdated && !loading && !error
+      ? new Date(lastUpdated).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })
+      : null;
+  const hasError = Boolean(error);
+  const badgeStatus = hasError ? 'header__badge--error' : loading ? 'header__badge--loading' : '';
+  const statusMessage = hasError ? error : loading ? 'Actualizando precio…' : formattedPrice;
+  const sublineMessage = hasError ? 'Revisa tu conexión' : sourceLabel;
+
   return (
     <header className="header">
       <div className="header__inner">
@@ -15,10 +39,31 @@ const Header = () => {
             <p>Diseña tu estrategia de retiro con datos en tiempo real.</p>
           </div>
         </div>
-        <nav className="header__actions" aria-label="Acciones rápidas">
-          <a href="#calculator-heading">Calculadora</a>
-          <a href="#dashboard-heading">Dashboard</a>
-        </nav>
+        <div className="header__meta">
+          <nav className="header__actions" aria-label="Acciones rápidas">
+            <a href="#calculator-heading">Calculadora</a>
+            <a href="#dashboard-heading">Dashboard</a>
+          </nav>
+          <div className="header__status" role="status" aria-live="polite">
+            <div className={`header__badge${badgeStatus ? ` ${badgeStatus}` : ''}`}>
+              <span className="header__badge-label">{statusMessage}</span>
+              <span className="header__badge-source">{sublineMessage}</span>
+              {updatedLabel ? (
+                <span className="header__badge-time">Última actualización: {updatedLabel}</span>
+              ) : null}
+            </div>
+            {typeof onRefresh === 'function' ? (
+              <button
+                type="button"
+                className="ghost-button header__refresh"
+                onClick={onRefresh}
+                disabled={loading}
+              >
+                {loading ? 'Sincronizando…' : 'Actualizar'}
+              </button>
+            ) : null}
+          </div>
+        </div>
       </div>
     </header>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
   --foreground: #f5f5f5;
   --muted-foreground: rgba(245, 245, 245, 0.65);
   --text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  --noise: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120"%3E%3Cfilter id="n" x="0" y="0" width="100%25" height="100%25"%3E%3CfeTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="4" stitchTiles="stitch"/%3E%3C/filter%3E%3Crect width="120" height="120" filter="url(%23n)" opacity="0.18"/%3E%3C/svg%3E');
 }
 
 a {
@@ -20,11 +21,35 @@ a:hover {
 }
 
 body {
+  position: relative;
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
   background: var(--background);
   color: var(--foreground);
+  overflow-x: hidden;
+}
+
+body::before,
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -2;
+}
+
+body::before {
+  background: radial-gradient(circle at 10% 10%, rgba(255, 255, 255, 0.12), transparent 40%),
+    radial-gradient(circle at 90% 15%, rgba(87, 124, 255, 0.12), transparent 45%);
+  opacity: 0.6;
+}
+
+body::after {
+  background: var(--noise);
+  mix-blend-mode: soft-light;
+  animation: noise-shift 6s steps(10) infinite;
+  opacity: 0.35;
 }
 
 h1,
@@ -42,4 +67,27 @@ button {
 
 * {
   box-sizing: border-box;
+}
+
+::selection {
+  background: rgba(247, 147, 26, 0.4);
+  color: #121212;
+}
+
+@keyframes noise-shift {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(-2%, 1%, 0);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body::after {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary
- refresh the global shell with layered gradients, elevated cards, and refined button states for a more premium layout
- enrich the header with a live pricing badge, status messaging, and inline refresh control tied to the realtime feed
- add wallet distribution insights to the calculator and a “Últimos movimientos” stream plus styled tooltip to the dashboard

## Testing
- npm install *(fails: 403 Forbidden fetching recharts)*
- npm run build *(fails: vite not found because dependencies are unavailable without install)*

------
https://chatgpt.com/codex/tasks/task_e_68d3866b2d608323adc233bfd484c270