### PR TITLE
feat: expand planner insights and dashboard tools

### DIFF
--- a/src/components/Calculator/Calculator.css
+++ b/src/components/Calculator/Calculator.css
@@ -215,6 +215,164 @@
   color: rgba(245, 245, 245, 0.75);
 }
 
+.calculator__scenario {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(247, 147, 26, 0.18), rgba(63, 94, 251, 0.12));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.calculator__scenario-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.calculator__scenario-header h3 {
+  margin: 0;
+}
+
+.calculator__scenario-header p {
+  margin: 0.35rem 0 0;
+  color: rgba(245, 245, 245, 0.75);
+  font-size: 0.9rem;
+}
+
+.calculator__scenario-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.5rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  background: rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.calculator__scenario input[type="range"] {
+  width: 100%;
+  accent-color: #f7931a;
+}
+
+.calculator__scenario-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.85rem;
+}
+
+.calculator__scenario-stats div {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem 0.95rem;
+  border-radius: 0.9rem;
+  background: rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.calculator__scenario-stats dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(245, 245, 245, 0.65);
+}
+
+.calculator__scenario-stats dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.calculator__scenario-positive {
+  color: #24d37a;
+}
+
+.calculator__scenario-negative {
+  color: #ff5f5f;
+}
+
+.calculator__advice {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  display: grid;
+  gap: 0.5rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.calculator__advice h3 {
+  margin: 0;
+}
+
+.calculator__advice p {
+  margin: 0;
+  color: rgba(245, 245, 245, 0.8);
+}
+
+.calculator__advice--info {
+  background: rgba(54, 91, 255, 0.16);
+}
+
+.calculator__advice--warning {
+  background: rgba(255, 95, 95, 0.16);
+}
+
+.calculator__advice--positive {
+  background: rgba(36, 211, 122, 0.16);
+}
+
+.calculator__advice--balanced {
+  background: rgba(247, 147, 26, 0.16);
+}
+
+.calculator__schedule {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.calculator__schedule-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.calculator__schedule table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.calculator__schedule th,
+.calculator__schedule td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.calculator__schedule tbody tr:last-child th,
+.calculator__schedule tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.calculator__schedule thead th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(245, 245, 245, 0.65);
+}
+
+.calculator__schedule tbody th {
+  color: rgba(245, 245, 245, 0.9);
+}
+
 .calculator__profiles {
   display: grid;
   gap: 1rem;
@@ -302,6 +460,11 @@
   .calculator__insights {
     grid-column: 1 / -1;
   }
+
+  .calculator__schedule-header {
+    flex-direction: row;
+    align-items: center;
+  }
 }
 
 @media (max-width: 768px) {
@@ -311,6 +474,11 @@
   }
 
   .calculator__profile-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .calculator__schedule-header {
     flex-direction: column;
     align-items: stretch;
   }

--- a/src/components/Dashboard/Dashboard.css
+++ b/src/components/Dashboard/Dashboard.css
@@ -23,7 +23,7 @@
 
 .dashboard__metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1.1rem;
   margin: 0;
 }
@@ -70,6 +70,79 @@
   color: var(--muted-foreground);
   text-align: center;
   padding: 2rem 0;
+}
+
+.dashboard__refresh {
+  display: grid;
+  gap: 0.6rem;
+  padding: 1.1rem;
+  border-radius: 1rem;
+  background: rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.dashboard__refresh-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.dashboard__refresh-header h3 {
+  margin: 0;
+}
+
+.dashboard__refresh-time {
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.dashboard__refresh-bar {
+  position: relative;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.dashboard__refresh-bar span {
+  position: absolute;
+  inset: 0;
+  display: block;
+  background: linear-gradient(90deg, #f7931a, #5d8bff);
+  transition: width 0.6s ease;
+}
+
+.dashboard__insights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.dashboard__insights article {
+  padding: 1rem 1.2rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.dashboard__insights h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+}
+
+.dashboard__insights p {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
 }
 
 .dashboard__recent {
@@ -135,6 +208,53 @@
   font-weight: 600;
 }
 
+.dashboard__resources {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.dashboard__resources h3 {
+  margin: 0;
+}
+
+.dashboard__resources ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dashboard__resources li a {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.9rem;
+  background: rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard__resources li a span {
+  font-weight: 600;
+}
+
+.dashboard__resources li a p {
+  margin: 0;
+  color: rgba(245, 245, 245, 0.75);
+  font-size: 0.9rem;
+}
+
+.dashboard__resources li a:hover,
+.dashboard__resources li a:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.28);
+}
+
 @media (max-width: 768px) {
   .dashboard__footer {
     justify-content: center;
@@ -146,5 +266,10 @@
 
   .dashboard__chip {
     justify-self: start;
+  }
+
+  .dashboard__refresh-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- add a simulator card in the calculator with price variation slider, projected withdrawal metrics, and strategy messaging
- generate a downloadable withdrawal calendar table with CSV export and refreshed styling for new widgets
- enhance the dashboard with live refresh countdown, aggregated history insights, and curated external resources

## Testing
- npm run lint *(fails: missing eslint-plugin-react because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d38d14112c83238cb4866adea26701