### PR TITLE
Improve mobile layout and add market insights

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -28,11 +28,11 @@
 
 .content-grid {
   position: relative;
-  width: min(1200px, calc(100% - 3rem));
+  width: min(1100px, calc(100% - 2.5rem));
   margin: 0 auto;
-  padding: 2.5rem 0 4.5rem;
+  padding: 2.25rem 0 4.25rem;
   display: grid;
-  gap: 2.5rem;
+  gap: 2.25rem;
 }
 
 .content-grid::before {
@@ -44,6 +44,11 @@
   background: linear-gradient(145deg, rgba(11, 16, 32, 0.6), rgba(8, 12, 24, 0.45));
   z-index: -1;
   box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+}
+
+#calculator-heading,
+#dashboard-heading {
+  scroll-margin-top: 120px;
 }
 
 .card {
@@ -129,10 +134,29 @@
   }
 }
 
+@media (max-width: 960px) {
+  .content-grid {
+    padding: 2rem 0 3.75rem;
+    gap: 2rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .content-grid {
+    width: calc(100% - 1.75rem);
+    gap: 1.85rem;
+  }
+
+  .card {
+    padding: 1.55rem;
+    border-radius: 1.4rem;
+  }
+}
+
 @media (max-width: 600px) {
   .content-grid {
-    width: calc(100% - 2rem);
-    padding: 2rem 0 3.5rem;
+    width: calc(100% - 1.5rem);
+    padding: 1.85rem 0 3.25rem;
   }
 
   .content-grid::before {
@@ -140,7 +164,13 @@
   }
 
   .card {
-    padding: 1.6rem;
+    padding: 1.45rem;
+  }
+}
+
+@media (max-width: 460px) {
+  .card {
+    padding: 1.3rem;
   }
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { UseBTCPrice } from './hooks/btc';
 
 const HISTORY_STORAGE_KEY = 'btc-history';
 const MAX_HISTORY_POINTS = 30;
+const AUTO_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 
 const safeParseHistory = value => {
   if (!value) return [];
@@ -25,7 +26,9 @@ const safeParseHistory = value => {
 };
 
 function App() {
-  const { price, source, loading, error, lastUpdated, refresh } = UseBTCPrice();
+  const { price, source, loading, error, lastUpdated, refresh } = UseBTCPrice(
+    AUTO_REFRESH_INTERVAL_MS
+  );
   const [history, setHistory] = useState(() => {
     if (typeof window === 'undefined') return [];
     return safeParseHistory(window.localStorage.getItem(HISTORY_STORAGE_KEY));
@@ -96,6 +99,7 @@ function App() {
           source={source}
           lastUpdated={lastUpdated}
           onClearHistory={clearHistory}
+          autoRefreshMs={AUTO_REFRESH_INTERVAL_MS}
         />
       </main>
     </div>

--- a/src/components/Calculator/Calculator.css
+++ b/src/components/Calculator/Calculator.css
@@ -483,3 +483,33 @@
     align-items: stretch;
   }
 }
+
+@media (max-width: 600px) {
+  .calculator {
+    gap: 1.45rem;
+  }
+
+  .calculator__price,
+  .calculator__result,
+  .calculator__insights,
+  .calculator__scenario,
+  .calculator__advice,
+  .calculator__schedule {
+    padding: 1.1rem;
+  }
+
+  .calculator__price-value {
+    font-size: 1.45rem;
+  }
+
+  .calculator__result-value {
+    font-size: 1.9rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .calculator__profile-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/src/components/Dashboard/Dashboard.css
+++ b/src/components/Dashboard/Dashboard.css
@@ -1,7 +1,7 @@
 .dashboard {
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.65rem;
 }
 
 .dashboard__header {
@@ -24,7 +24,7 @@
 .dashboard__metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1.1rem;
+  gap: 1rem;
   margin: 0;
 }
 
@@ -74,7 +74,7 @@
 
 .dashboard__refresh {
   display: grid;
-  gap: 0.6rem;
+  gap: 0.55rem;
   padding: 1.1rem;
   border-radius: 1rem;
   background: rgba(0, 0, 0, 0.25);
@@ -145,6 +145,71 @@
   font-weight: 600;
 }
 
+.dashboard__pulse {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.dashboard__pulse-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.dashboard__pulse-header h3 {
+  margin: 0;
+}
+
+.dashboard__pulse-status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted-foreground);
+}
+
+.dashboard__pulse-status--error {
+  color: #ff8c8c;
+}
+
+.dashboard__pulse-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.dashboard__pulse-grid li {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.9rem;
+  background: rgba(0, 0, 0, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.dashboard__pulse-grid span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+}
+
+.dashboard__pulse-grid strong {
+  font-size: 1.05rem;
+}
+
+.dashboard__pulse-updated {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(245, 245, 245, 0.6);
+}
+
 .dashboard__recent {
   display: grid;
   gap: 0.75rem;
@@ -199,9 +264,166 @@
   color: #ff7878;
 }
 
+.dashboard__targets {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.dashboard__targets-header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.dashboard__targets-header h3 {
+  margin: 0;
+}
+
+.dashboard__target-form {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.dashboard__target-form input,
+.dashboard__target-form select {
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.02);
+  color: inherit;
+}
+
+.dashboard__target-form input:focus,
+.dashboard__target-form select:focus {
+  outline: 2px solid rgba(247, 147, 26, 0.6);
+  border-color: transparent;
+  box-shadow: 0 0 0 4px rgba(247, 147, 26, 0.15);
+}
+
+.dashboard__target-submit {
+  justify-self: flex-start;
+}
+
+.dashboard__target-error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #ff8c8c;
+}
+
+.dashboard__target-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dashboard__target-item {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.9rem 1rem;
+  border-radius: 0.95rem;
+  background: rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard__target-item--ready {
+  box-shadow: inset 0 0 0 1px rgba(36, 211, 122, 0.35);
+}
+
+.dashboard__target-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.dashboard__target-heading h4 {
+  margin: 0 0 0.35rem;
+}
+
+.dashboard__target-heading p {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.85rem;
+}
+
+.dashboard__target-remove {
+  padding-inline: 0.85rem;
+}
+
+.dashboard__target-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.dashboard__target-status {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 0.82rem;
+}
+
+.dashboard__target-status--ready {
+  background: rgba(36, 211, 122, 0.18);
+  color: #24d37a;
+}
+
+.dashboard__target-diff {
+  font-size: 0.85rem;
+  color: rgba(245, 245, 245, 0.75);
+}
+
+.dashboard__target-progress-label {
+  font-size: 0.8rem;
+  color: rgba(245, 245, 245, 0.65);
+  margin-left: auto;
+}
+
+.dashboard__target-progress {
+  position: relative;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.dashboard__target-progress span {
+  position: absolute;
+  inset: 0;
+  display: block;
+  background: linear-gradient(90deg, #f7931a, #5d8bff);
+  transition: width 0.3s ease;
+}
+
+.dashboard__target-empty {
+  margin: 0;
+  padding: 0.5rem 0;
+  color: var(--muted-foreground);
+  text-align: center;
+}
+
+.dashboard__recent-value,
+.dashboard__target-diff,
+.dashboard__pulse-grid strong {
+  font-weight: 600;
+}
+
 .dashboard__footer {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .dashboard__tooltip-label {
@@ -256,10 +478,6 @@
 }
 
 @media (max-width: 768px) {
-  .dashboard__footer {
-    justify-content: center;
-  }
-
   .dashboard__recent-item {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -271,5 +489,37 @@
   .dashboard__refresh-header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .dashboard__target-form {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dashboard__target-submit {
+    width: 100%;
+  }
+
+  .dashboard__target-progress-label {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dashboard__pulse-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dashboard__pulse-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dashboard__footer {
+    justify-content: center;
   }
 }

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import './Dashboard.css';
 import {
   Area,
@@ -26,9 +26,87 @@ const numberFormatter = new Intl.NumberFormat('es-ES', {
   maximumFractionDigits: 2,
 });
 
+const percentageFormatter = new Intl.NumberFormat('es-ES', {
+  maximumFractionDigits: 2,
+});
+
 const tooltipFormatter = value => currencyFormatter.format(value);
 
-const REFRESH_INTERVAL_SECONDS = 60;
+const TARGETS_STORAGE_KEY = 'btc-targets';
+
+const createTargetId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `target-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const safeParseTargets = value => {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map(target => {
+        const numericValue = Number(target?.value);
+        if (!Number.isFinite(numericValue) || numericValue <= 0) return null;
+        const label =
+          typeof target?.label === 'string' && target.label.trim()
+            ? target.label.trim()
+            : 'Objetivo sin nombre';
+        const type = target?.type === 'below' ? 'below' : 'above';
+        return {
+          id: typeof target?.id === 'string' ? target.id : createTargetId(),
+          label,
+          value: numericValue,
+          type,
+        };
+      })
+      .filter(Boolean);
+  } catch (error) {
+    return [];
+  }
+};
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const formatIntervalLabel = seconds => {
+  if (!seconds) return 'sin programación';
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  const parts = [];
+  if (hours) parts.push(`${hours} ${hours === 1 ? 'hora' : 'horas'}`);
+  if (minutes) parts.push(`${minutes} min`);
+  if (!hours && !minutes && secs) parts.push(`${secs} s`);
+  return parts.join(' ') || `${secs} s`;
+};
+
+const formatNextRefreshLabel = seconds => {
+  if (seconds === null) return 'Sin datos';
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  if (hours > 0) {
+    return `${hours}h ${String(minutes).padStart(2, '0')}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${String(secs).padStart(2, '0')}s`;
+  }
+  return `${secs}s`;
+};
+
+const formatElapsedLabel = seconds => {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  if (hours > 0) {
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(
+      secs
+    ).padStart(2, '0')}`;
+  }
+  return `${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+};
 
 export function Dashboard({
   username = 'Guest',
@@ -39,9 +117,11 @@ export function Dashboard({
   source,
   lastUpdated,
   onClearHistory,
+  autoRefreshMs = 0,
 }) {
-  const hasHistory = Array.isArray(history) && history.length > 0;
-  const safeRawHistory = Array.isArray(rawHistory) ? rawHistory : [];
+  const safeHistory = useMemo(() => (Array.isArray(history) ? history : []), [history]);
+  const safeRawHistory = useMemo(() => (Array.isArray(rawHistory) ? rawHistory : []), [rawHistory]);
+  const hasHistory = safeHistory.length > 0;
   const latestEntry = hasHistory ? safeRawHistory.at(-1) : null;
   const firstEntry = hasHistory ? safeRawHistory[0] : null;
   const variation =
@@ -49,11 +129,27 @@ export function Dashboard({
       ? ((latestEntry.price - firstEntry.price) / firstEntry.price) * 100
       : 0;
 
-  const formattedVariation = `${variation >= 0 ? '+' : ''}${numberFormatter.format(
-    variation
-  )}%`;
+  const formattedVariation = `${variation >= 0 ? '+' : ''}${numberFormatter.format(variation)}%`;
   const recentHistory = hasHistory ? [...safeRawHistory].slice(-4).reverse() : [];
   const [secondsSinceUpdate, setSecondsSinceUpdate] = useState(0);
+  const refreshIntervalSeconds = useMemo(
+    () => (autoRefreshMs > 0 ? Math.round(autoRefreshMs / 1000) : 0),
+    [autoRefreshMs]
+  );
+  const [targets, setTargets] = useState(() => {
+    if (typeof window === 'undefined') return [];
+    return safeParseTargets(window.localStorage.getItem(TARGETS_STORAGE_KEY));
+  });
+  const [targetLabel, setTargetLabel] = useState('');
+  const [targetValue, setTargetValue] = useState('');
+  const [targetType, setTargetType] = useState('above');
+  const [targetError, setTargetError] = useState('');
+  const [marketPulse, setMarketPulse] = useState({ loading: true, error: null, data: null });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(TARGETS_STORAGE_KEY, JSON.stringify(targets));
+  }, [targets]);
 
   useEffect(() => {
     if (!lastUpdated) {
@@ -62,10 +158,7 @@ export function Dashboard({
     }
 
     const updateCounter = () => {
-      const diff = Math.max(
-        0,
-        Math.floor((Date.now() - new Date(lastUpdated).getTime()) / 1000)
-      );
+      const diff = Math.max(0, Math.floor((Date.now() - new Date(lastUpdated).getTime()) / 1000));
       setSecondsSinceUpdate(diff);
     };
 
@@ -74,28 +167,75 @@ export function Dashboard({
     return () => window.clearInterval(interval);
   }, [lastUpdated]);
 
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    const fetchGlobalData = async () => {
+      try {
+        const res = await fetch('https://api.coingecko.com/api/v3/global', {
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`Global ${res.status}`);
+        const json = await res.json();
+        if (cancelled) return;
+        const raw = json?.data;
+        const marketCapEur = Number(raw?.total_market_cap?.eur);
+        const volumeEur = Number(raw?.total_volume?.eur);
+        const btcDominance = Number(raw?.market_cap_percentage?.btc);
+        const marketChange = Number(raw?.market_cap_change_percentage_24h_usd);
+        const updatedAt = raw?.updated_at ? new Date(raw.updated_at * 1000).toISOString() : null;
+
+        setMarketPulse({
+          loading: false,
+          error: null,
+          data: {
+            marketCapEur: Number.isFinite(marketCapEur) ? marketCapEur : null,
+            volumeEur: Number.isFinite(volumeEur) ? volumeEur : null,
+            btcDominance: Number.isFinite(btcDominance) ? btcDominance : null,
+            marketChange: Number.isFinite(marketChange) ? marketChange : null,
+            updatedAt,
+          },
+        });
+      } catch (error) {
+        if (cancelled) return;
+        setMarketPulse({ loading: false, error: 'Datos globales no disponibles', data: null });
+      }
+    };
+
+    fetchGlobalData();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, []);
+
   const timeToNextRefresh = useMemo(() => {
-    if (!lastUpdated) return null;
-    const modulo = secondsSinceUpdate % REFRESH_INTERVAL_SECONDS;
-    return modulo === 0 ? REFRESH_INTERVAL_SECONDS : REFRESH_INTERVAL_SECONDS - modulo;
-  }, [secondsSinceUpdate, lastUpdated]);
+    if (!lastUpdated || !refreshIntervalSeconds) return null;
+    const modulo = secondsSinceUpdate % refreshIntervalSeconds;
+    return modulo === 0 ? refreshIntervalSeconds : refreshIntervalSeconds - modulo;
+  }, [secondsSinceUpdate, lastUpdated, refreshIntervalSeconds]);
 
   const refreshProgress = useMemo(() => {
-    if (!lastUpdated || timeToNextRefresh === null) return 0;
-    return ((REFRESH_INTERVAL_SECONDS - timeToNextRefresh) / REFRESH_INTERVAL_SECONDS) * 100;
-  }, [lastUpdated, timeToNextRefresh]);
+    if (!lastUpdated || !refreshIntervalSeconds || timeToNextRefresh === null) return 0;
+    return ((refreshIntervalSeconds - timeToNextRefresh) / refreshIntervalSeconds) * 100;
+  }, [lastUpdated, timeToNextRefresh, refreshIntervalSeconds]);
 
   const elapsedLabel = useMemo(() => {
     if (!lastUpdated) return 'Sin datos';
-    const minutes = Math.floor(secondsSinceUpdate / 60);
-    const seconds = secondsSinceUpdate % 60;
-    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+    return formatElapsedLabel(secondsSinceUpdate);
   }, [lastUpdated, secondsSinceUpdate]);
 
   const nextRefreshLabel = useMemo(() => {
-    if (!timeToNextRefresh) return 'Sin datos';
-    return `${timeToNextRefresh}s`;
-  }, [timeToNextRefresh]);
+    if (!lastUpdated || timeToNextRefresh === null) return 'Sin datos';
+    return formatNextRefreshLabel(timeToNextRefresh);
+  }, [lastUpdated, timeToNextRefresh]);
+
+  const refreshIntervalLabel = useMemo(
+    () => formatIntervalLabel(refreshIntervalSeconds),
+    [refreshIntervalSeconds]
+  );
 
   const highestPrice = useMemo(() => {
     if (!hasHistory) return null;
@@ -111,6 +251,23 @@ export function Dashboard({
     if (!hasHistory || safeRawHistory.length === 0) return null;
     const sum = safeRawHistory.reduce((total, entry) => total + entry.price, 0);
     return sum / safeRawHistory.length;
+  }, [hasHistory, safeRawHistory]);
+
+  const volatility = useMemo(() => {
+    if (!hasHistory || safeRawHistory.length < 2) return null;
+    const mean =
+      safeRawHistory.reduce((total, entry) => total + entry.price, 0) / safeRawHistory.length;
+    if (!Number.isFinite(mean) || mean === 0) return null;
+    const variance =
+      safeRawHistory.reduce((total, entry) => total + Math.pow(entry.price - mean, 2), 0) /
+      (safeRawHistory.length - 1);
+    if (!Number.isFinite(variance)) return null;
+    const stdDev = Math.sqrt(variance);
+    if (!Number.isFinite(stdDev)) return null;
+    return {
+      stdDev,
+      percent: (stdDev / mean) * 100,
+    };
   }, [hasHistory, safeRawHistory]);
 
   const insights = useMemo(
@@ -134,8 +291,14 @@ export function Dashboard({
         label: 'Capturas guardadas',
         value: hasHistory ? `${safeRawHistory.length}` : '0',
       },
+      {
+        label: 'Volatilidad histórica',
+        value: volatility
+          ? `${numberFormatter.format(volatility.percent)}% σ`
+          : 'Sin historial',
+      },
     ],
-    [averagePrice, hasHistory, highestPrice, lowestPrice, safeRawHistory.length]
+    [averagePrice, hasHistory, highestPrice, lowestPrice, safeRawHistory.length, volatility]
   );
 
   const resources = useMemo(
@@ -155,9 +318,159 @@ export function Dashboard({
         description: 'Consulta el pulso del mercado para complementar tus escenarios.',
         href: 'https://alternative.me/crypto/fear-and-greed-index/',
       },
+      {
+        title: 'Calcula tu coste medio',
+        description: 'Herramientas para seguir tus compras acumuladas por precio.',
+        href: 'https://www.coingecko.com/es/calculadora-de-coste-medio',
+      },
     ],
     []
   );
+
+  const marketPulseItems = useMemo(() => {
+    if (!marketPulse.data) return [];
+    const items = [];
+    if (marketPulse.data.marketCapEur) {
+      items.push({
+        label: 'Capitalización global',
+        value: currencyFormatter.format(marketPulse.data.marketCapEur),
+      });
+    }
+    if (marketPulse.data.volumeEur) {
+      items.push({
+        label: 'Volumen 24h',
+        value: currencyFormatter.format(marketPulse.data.volumeEur),
+      });
+    }
+    if (marketPulse.data.btcDominance !== null) {
+      items.push({
+        label: 'Dominancia BTC',
+        value: `${percentageFormatter.format(marketPulse.data.btcDominance)}%`,
+      });
+    }
+    if (marketPulse.data.marketChange !== null) {
+      const formatted = `${
+        marketPulse.data.marketChange >= 0 ? '+' : ''
+      }${percentageFormatter.format(marketPulse.data.marketChange)}%`;
+      items.push({
+        label: 'Variación mercado 24h',
+        value: formatted,
+        intent:
+          marketPulse.data.marketChange >= 0 ? 'dashboard__positive' : 'dashboard__negative',
+      });
+    }
+    return items;
+  }, [marketPulse]);
+
+  const marketPulseUpdatedLabel = useMemo(() => {
+    if (!marketPulse.data?.updatedAt) return null;
+    return new Date(marketPulse.data.updatedAt).toLocaleTimeString('es-ES', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }, [marketPulse]);
+
+  const enhancedTargets = useMemo(() => {
+    if (!Array.isArray(targets)) return [];
+    const currentPrice = typeof price === 'number' && Number.isFinite(price) ? price : null;
+    return targets.map(target => {
+      const safeValue = target.value;
+      const reached =
+        currentPrice === null
+          ? false
+          : target.type === 'above'
+          ? currentPrice >= safeValue
+          : currentPrice <= safeValue;
+      const rawDifference =
+        currentPrice === null
+          ? null
+          : target.type === 'above'
+          ? currentPrice - safeValue
+          : safeValue - currentPrice;
+      let differenceLabel = 'Sin precio';
+      if (rawDifference !== null) {
+        if (rawDifference === 0) {
+          differenceLabel = 'En objetivo';
+        } else {
+          const prefix = rawDifference > 0 ? '+' : '-';
+          differenceLabel = `${prefix}${currencyFormatter.format(Math.abs(rawDifference))}`;
+        }
+      }
+      let progress = 0;
+      if (currentPrice && safeValue > 0) {
+        if (target.type === 'above') {
+          progress = clamp((currentPrice / safeValue) * 100, 0, 100);
+        } else {
+          progress = currentPrice <= safeValue ? 100 : clamp((safeValue / currentPrice) * 100, 0, 100);
+        }
+      } else if (currentPrice === 0 && safeValue > 0 && target.type === 'below') {
+        progress = 100;
+      }
+      const statusLabel =
+        currentPrice === null
+          ? 'Esperando precio actual'
+          : reached
+          ? target.type === 'above'
+            ? 'Objetivo de venta listo'
+            : 'Objetivo de compra listo'
+          : target.type === 'above'
+          ? 'Todavía por debajo del objetivo'
+          : 'Todavía por encima del objetivo';
+      return {
+        ...target,
+        reached,
+        differenceLabel,
+        progress,
+        statusLabel,
+      };
+    });
+  }, [targets, price]);
+
+  const handleAddTarget = useCallback(
+    event => {
+      event.preventDefault();
+      const parsedValue = Number(targetValue);
+      const cleanLabel = targetLabel.trim();
+      if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+        setTargetError('Introduce un importe válido en euros.');
+        return;
+      }
+      if (!cleanLabel) {
+        setTargetError('Añade un nombre descriptivo para el objetivo.');
+        return;
+      }
+      const type = targetType === 'below' ? 'below' : 'above';
+      setTargets(prev => [
+        ...prev,
+        { id: createTargetId(), label: cleanLabel, value: parsedValue, type },
+      ]);
+      setTargetLabel('');
+      setTargetValue('');
+      setTargetType('above');
+      setTargetError('');
+    },
+    [targetLabel, targetValue, targetType]
+  );
+
+  const handleRemoveTarget = useCallback(id => {
+    setTargets(prev => prev.filter(target => target.id !== id));
+  }, []);
+
+  const handleExportHistory = useCallback(() => {
+    if (!hasHistory || typeof window === 'undefined') return;
+    const header = 'time,price\n';
+    const rows = safeRawHistory.map(entry => `${entry.time},${entry.price}`).join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const formattedDate = new Date().toISOString().replace(/[:T]/g, '-').split('.')[0];
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `btc-history-${formattedDate}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [hasHistory, safeRawHistory]);
 
   return (
     <section className="dashboard card" aria-labelledby="dashboard-heading">
@@ -220,7 +533,7 @@ export function Dashboard({
       <div className="dashboard__chart" role="img" aria-label="Histórico del precio en euros">
         {hasHistory ? (
           <ResponsiveContainer width="100%" height={280}>
-            <AreaChart data={history} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+            <AreaChart data={safeHistory} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
               <defs>
                 <linearGradient id="priceGradient" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="0%" stopColor="#f7931a" stopOpacity={0.9} />
@@ -261,21 +574,56 @@ export function Dashboard({
           <h3>Sincronización automática</h3>
           <span className="dashboard__refresh-time">{nextRefreshLabel}</span>
         </div>
-        <div className="dashboard__refresh-bar" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={Math.round(refreshProgress)}>
+        <div
+          className="dashboard__refresh-bar"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(refreshProgress)}
+        >
           <span style={{ width: `${refreshProgress}%` }} />
         </div>
         <p className="help">
-          Este panel se actualiza cada {REFRESH_INTERVAL_SECONDS} segundos. Usa el botón de refresco del encabezado para forzar una nueva lectura.
+          Este panel se actualiza cada {refreshIntervalLabel}. Usa el botón de refresco del encabezado
+          para forzar una nueva lectura.
         </p>
       </section>
 
       <section className="dashboard__insights" aria-label="Resumen del historial">
-        {insights.map((item) => (
+        {insights.map(item => (
           <article key={item.label}>
             <h3>{item.label}</h3>
             <p>{item.value}</p>
           </article>
         ))}
+      </section>
+
+      <section className="dashboard__pulse" aria-label="Pulso global del mercado">
+        <div className="dashboard__pulse-header">
+          <h3>Radar de mercado</h3>
+          <p className="help">Contexto externo cortesía de CoinGecko para tus decisiones.</p>
+        </div>
+        {marketPulse.loading ? (
+          <p className="dashboard__pulse-status">Cargando mercado…</p>
+        ) : marketPulse.error ? (
+          <p className="dashboard__pulse-status dashboard__pulse-status--error">
+            {marketPulse.error}
+          </p>
+        ) : (
+          <>
+            <ul className="dashboard__pulse-grid">
+              {marketPulseItems.map(item => (
+                <li key={item.label}>
+                  <span>{item.label}</span>
+                  <strong className={item.intent}>{item.value}</strong>
+                </li>
+              ))}
+            </ul>
+            {marketPulseUpdatedLabel ? (
+              <p className="dashboard__pulse-updated">Actualizado a las {marketPulseUpdatedLabel}</p>
+            ) : null}
+          </>
+        )}
       </section>
 
       {recentHistory.length > 0 ? (
@@ -300,7 +648,9 @@ export function Dashboard({
                   <span className="dashboard__recent-time">
                     {new Date(entry.time).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}
                   </span>
-                  <span className="dashboard__recent-value">{currencyFormatter.format(entry.price)}</span>
+                  <span className="dashboard__recent-value">
+                    {currencyFormatter.format(entry.price)}
+                  </span>
                   <span className={`dashboard__chip ${diffClass}`}>{chipContent}</span>
                 </li>
               );
@@ -309,7 +659,117 @@ export function Dashboard({
         </section>
       ) : null}
 
+      <section className="dashboard__targets" aria-label="Alertas personales de precio">
+        <div className="dashboard__targets-header">
+          <h3>Alertas personalizadas</h3>
+          <p className="help">Define niveles clave para reaccionar rápido ante el mercado.</p>
+        </div>
+        <form className="dashboard__target-form" onSubmit={handleAddTarget}>
+          <label className="visualmente-oculto" htmlFor="target-label">
+            Nombre del objetivo
+          </label>
+          <input
+            id="target-label"
+            name="target-label"
+            type="text"
+            placeholder="Etiqueta (ej. Venta parcial)"
+            value={targetLabel}
+            onChange={event => setTargetLabel(event.target.value)}
+            required
+          />
+          <label className="visualmente-oculto" htmlFor="target-value">
+            Precio objetivo en euros
+          </label>
+          <input
+            id="target-value"
+            name="target-value"
+            type="number"
+            min="0"
+            step="0.01"
+            placeholder="Precio objetivo en EUR"
+            value={targetValue}
+            onChange={event => setTargetValue(event.target.value)}
+            required
+          />
+          <label className="visualmente-oculto" htmlFor="target-type">
+            Tipo de objetivo
+          </label>
+          <select
+            id="target-type"
+            name="target-type"
+            value={targetType}
+            onChange={event => setTargetType(event.target.value)}
+          >
+            <option value="above">Vender cuando supere</option>
+            <option value="below">Comprar cuando baje a</option>
+          </select>
+          <button type="submit" className="primary-button dashboard__target-submit">
+            Guardar objetivo
+          </button>
+        </form>
+        {targetError ? <p className="dashboard__target-error">{targetError}</p> : null}
+        <ul className="dashboard__target-list">
+          {enhancedTargets.length > 0 ? (
+            enhancedTargets.map(target => (
+              <li
+                key={target.id}
+                className={`dashboard__target-item${target.reached ? ' dashboard__target-item--ready' : ''}`}
+              >
+                <div className="dashboard__target-heading">
+                  <div>
+                    <h4>{target.label}</h4>
+                    <p>
+                      {target.type === 'above' ? 'Superar' : 'Descender hasta'}{' '}
+                      {currencyFormatter.format(target.value)}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="ghost-button dashboard__target-remove"
+                    onClick={() => handleRemoveTarget(target.id)}
+                  >
+                    Quitar
+                  </button>
+                </div>
+                <div className="dashboard__target-meta">
+                  <span
+                    className={`dashboard__target-status${
+                      target.reached ? ' dashboard__target-status--ready' : ''
+                    }`}
+                  >
+                    {target.statusLabel}
+                  </span>
+                  <span className="dashboard__target-diff">{target.differenceLabel}</span>
+                  <span className="dashboard__target-progress-label">
+                    Progreso {Math.round(target.progress)}%
+                  </span>
+                </div>
+                <div
+                  className="dashboard__target-progress"
+                  role="progressbar"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={Math.round(target.progress)}
+                >
+                  <span style={{ width: `${target.progress}%` }} />
+                </div>
+              </li>
+            ))
+          ) : (
+            <li className="dashboard__target-empty">Aún no has definido objetivos de precio.</li>
+          )}
+        </ul>
+      </section>
+
       <footer className="dashboard__footer">
+        <button
+          type="button"
+          onClick={handleExportHistory}
+          className="ghost-button"
+          disabled={!hasHistory}
+        >
+          Exportar historial
+        </button>
         <button type="button" onClick={onClearHistory} className="secondary-button">
           Limpiar historial
         </button>
@@ -318,7 +778,7 @@ export function Dashboard({
       <section className="dashboard__resources" aria-label="Recursos recomendados">
         <h3>Inspiración para tu estrategia</h3>
         <ul>
-          {resources.map((resource) => (
+          {resources.map(resource => (
             <li key={resource.href}>
               <a href={resource.href} target="_blank" rel="noreferrer">
                 <span>{resource.title}</span>

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -2,11 +2,10 @@
   position: sticky;
   top: 0;
   z-index: 10;
-  backdrop-filter: blur(14px);
-  background: linear-gradient(135deg, rgba(8, 16, 32, 0.9), rgba(20, 28, 48, 0.8));
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(16px);
+  background: linear-gradient(135deg, rgba(6, 12, 24, 0.92), rgba(18, 26, 46, 0.85));
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.32);
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-  overflow: hidden;
 }
 
 .header::after {
@@ -14,49 +13,100 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 15% 120%, rgba(247, 147, 26, 0.22), transparent 55%),
-    radial-gradient(circle at 85% -60%, rgba(77, 106, 255, 0.18), transparent 45%);
-  opacity: 0.9;
+  background: radial-gradient(circle at 15% 120%, rgba(247, 147, 26, 0.2), transparent 55%),
+    radial-gradient(circle at 85% -60%, rgba(77, 106, 255, 0.16), transparent 45%);
+  opacity: 0.8;
 }
 
 .header__inner {
   position: relative;
   margin: 0 auto;
   max-width: 1200px;
-  padding: 1rem 1.5rem;
+  padding: 0.75rem 1.25rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1.5rem;
-  flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .header__brand {
   display: flex;
   align-items: center;
+  gap: 0.75rem;
+}
+
+.header__brand-copy h1 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.header__brand-copy p {
+  margin: 0.2rem 0 0;
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+}
+
+.header__controls {
+  display: flex;
+  align-items: center;
   gap: 1rem;
 }
 
-.header__brand h1 {
-  margin: 0;
-  font-size: 1.65rem;
+.header__menu-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
 }
 
-.header__brand p {
-  margin: 0.25rem 0 0;
-  font-size: 0.95rem;
-  color: var(--muted-foreground);
+.header__menu-toggle span[aria-hidden='true'] {
+  display: block;
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.header__menu-toggle span[aria-hidden='true'] + span[aria-hidden='true'] {
+  margin-top: 4px;
+}
+
+.header--open .header__menu-toggle span[aria-hidden='true']:nth-child(2) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.header--open .header__menu-toggle span[aria-hidden='true']:nth-child(3) {
+  opacity: 0;
+}
+
+.header--open .header__menu-toggle span[aria-hidden='true']:nth-child(4) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.header__menu-toggle:hover,
+.header__menu-toggle:focus {
+  background: rgba(247, 147, 26, 0.18);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
+  outline: none;
 }
 
 .header__meta {
   display: flex;
   align-items: center;
-  gap: 1.25rem;
+  gap: 1.1rem;
 }
 
 .header__actions {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.65rem;
   padding: 0.25rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.06);
@@ -66,38 +116,36 @@
 .header__actions a {
   color: inherit;
   font-weight: 600;
-  padding: 0.4rem 0.85rem;
+  padding: 0.38rem 0.8rem;
   border-radius: 999px;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
 .header__actions a:hover,
 .header__actions a:focus {
-  background: rgba(247, 147, 26, 0.2);
-  color: #fff4e2;
+  background: rgba(247, 147, 26, 0.24);
+  color: #fff5e6;
   outline: none;
 }
 
 .header__status {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  justify-content: flex-end;
+  gap: 0.65rem;
 }
 
 .header__badge {
-  min-width: 220px;
+  min-width: 200px;
   display: grid;
   gap: 0.15rem;
-  padding: 0.6rem 0.9rem;
-  border-radius: 0.9rem;
-  background: rgba(0, 0, 0, 0.35);
+  padding: 0.55rem 0.85rem;
+  border-radius: 0.85rem;
+  background: rgba(0, 0, 0, 0.32);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .header__badge--loading {
-  background: linear-gradient(135deg, rgba(247, 147, 26, 0.2), rgba(247, 147, 26, 0.05));
+  background: linear-gradient(135deg, rgba(247, 147, 26, 0.22), rgba(247, 147, 26, 0.08));
   box-shadow: inset 0 0 0 1px rgba(247, 147, 26, 0.3);
 }
 
@@ -117,17 +165,17 @@
 
 .header__badge-label {
   font-weight: 700;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
 }
 
 .header__badge-source,
 .header__badge-time {
-  font-size: 0.75rem;
+  font-size: 0.74rem;
   color: var(--muted-foreground);
 }
 
 .header__refresh {
-  padding-inline: 1rem;
+  padding: 0.45rem 0.95rem;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
@@ -144,30 +192,77 @@
   transform: none;
 }
 
-@media (max-width: 900px) {
-  .header__meta {
-    width: 100%;
-    justify-content: space-between;
-    flex-wrap: wrap;
-  }
-
-  .header__status {
-    width: 100%;
-    justify-content: space-between;
-  }
-}
-
-@media (max-width: 640px) {
+@media (max-width: 960px) {
   .header__inner {
     align-items: flex-start;
   }
 
+  .header__controls {
+    align-items: flex-start;
+  }
+
+  .header__menu-toggle {
+    display: inline-flex;
+  }
+
   .header__meta {
+    position: absolute;
+    top: calc(100% - 0.35rem);
+    right: 1.25rem;
+    min-width: min(320px, calc(100vw - 2.5rem));
+    padding: 1rem;
+    border-radius: 1rem;
+    background: rgba(8, 12, 24, 0.92);
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.38);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    display: grid;
     gap: 1rem;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(0.5rem);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .header__meta--open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0.85rem);
+  }
+
+  .header__actions {
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+  }
+
+  .header__actions a {
+    width: 100%;
   }
 
   .header__status {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .header__badge {
+    width: 100%;
+  }
+
+  .header__refresh {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .header__inner {
+    padding: 0.65rem 1rem;
+  }
+
+  .header__brand-copy h1 {
+    font-size: 1.2rem;
+  }
+
+  .header__brand-copy p {
+    font-size: 0.8rem;
   }
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import './Header.css';
 import { Image } from '../Image/Image';
 
@@ -25,43 +26,89 @@ const Header = ({ price, source, lastUpdated, loading, error, onRefresh }) => {
   const badgeStatus = hasError ? 'header__badge--error' : loading ? 'header__badge--loading' : '';
   const statusMessage = hasError ? error : loading ? 'Actualizando precio…' : formattedPrice;
   const sublineMessage = hasError ? 'Revisa tu conexión' : sourceLabel;
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 960) {
+        setMenuOpen(false);
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const toggleMenu = () => {
+    setMenuOpen(prev => !prev);
+  };
+
+  const closeMenu = () => {
+    setMenuOpen(false);
+  };
 
   return (
-    <header className="header">
+    <header className={`header${menuOpen ? ' header--open' : ''}`}>
       <div className="header__inner">
         <div className="header__brand">
           <Image
             src="https://seeklogo.com/images/W/wrapped-bitcoin-wbtc-logo-A3917F45C9-seeklogo.com.png"
             alt="Bitcoin"
           />
-          <div>
+          <div className="header__brand-copy">
             <h1>Calculadora de BTC</h1>
             <p>Diseña tu estrategia de retiro con datos en tiempo real.</p>
           </div>
         </div>
-        <div className="header__meta">
-          <nav className="header__actions" aria-label="Acciones rápidas">
-            <a href="#calculator-heading">Calculadora</a>
-            <a href="#dashboard-heading">Dashboard</a>
-          </nav>
-          <div className="header__status" role="status" aria-live="polite">
-            <div className={`header__badge${badgeStatus ? ` ${badgeStatus}` : ''}`}>
-              <span className="header__badge-label">{statusMessage}</span>
-              <span className="header__badge-source">{sublineMessage}</span>
-              {updatedLabel ? (
-                <span className="header__badge-time">Última actualización: {updatedLabel}</span>
+        <div className="header__controls">
+          <button
+            type="button"
+            className="header__menu-toggle"
+            onClick={toggleMenu}
+            aria-expanded={menuOpen}
+            aria-controls="header-navigation"
+          >
+            <span className="visualmente-oculto">
+              {menuOpen ? 'Cerrar navegación principal' : 'Abrir navegación principal'}
+            </span>
+            <span aria-hidden="true" />
+            <span aria-hidden="true" />
+            <span aria-hidden="true" />
+          </button>
+          <div
+            className={`header__meta${menuOpen ? ' header__meta--open' : ''}`}
+            id="header-navigation"
+          >
+            <nav className="header__actions" aria-label="Acciones rápidas">
+              <a href="#calculator-heading" onClick={closeMenu}>
+                Calculadora
+              </a>
+              <a href="#dashboard-heading" onClick={closeMenu}>
+                Dashboard
+              </a>
+            </nav>
+            <div className="header__status" role="status" aria-live="polite">
+              <div className={`header__badge${badgeStatus ? ` ${badgeStatus}` : ''}`}>
+                <span className="header__badge-label">{statusMessage}</span>
+                <span className="header__badge-source">{sublineMessage}</span>
+                {updatedLabel ? (
+                  <span className="header__badge-time">Actualizado a las {updatedLabel}</span>
+                ) : null}
+              </div>
+              {typeof onRefresh === 'function' ? (
+                <button
+                  type="button"
+                  className="ghost-button header__refresh"
+                  onClick={() => {
+                    closeMenu();
+                    onRefresh();
+                  }}
+                  disabled={loading}
+                >
+                  {loading ? 'Sincronizando…' : 'Actualizar'}
+                </button>
               ) : null}
             </div>
-            {typeof onRefresh === 'function' ? (
-              <button
-                type="button"
-                className="ghost-button header__refresh"
-                onClick={onRefresh}
-                disabled={loading}
-              >
-                {loading ? 'Sincronizando…' : 'Actualizar'}
-              </button>
-            ) : null}
           </div>
         </div>
       </div>

--- a/src/components/Image/Image.css
+++ b/src/components/Image/Image.css
@@ -1,5 +1,13 @@
 .image {
-  width: 64px;
-  height: 64px;
+  width: 56px;
+  height: 56px;
   object-fit: contain;
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.35));
+}
+
+@media (max-width: 600px) {
+  .image {
+    width: 48px;
+    height: 48px;
+  }
 }

--- a/src/hooks/btc.js
+++ b/src/hooks/btc.js
@@ -11,10 +11,10 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 
 /**
  * Hook to obtain the Bitcoin price from multiple providers.
- * @param {number} [refreshMs=60000]
+ * @param {number} [refreshMs=3600000]
  * @returns {BTCState & { refresh: () => Promise<void> }}
  */
-export function UseBTCPrice(refreshMs = 60000) {
+export function UseBTCPrice(refreshMs = 60 * 60 * 1000) {
   const [state, setState] = useState(
     /** @type {BTCState} */ ({
       price: null,


### PR DESCRIPTION
## Summary
- Ajusté el refresco automático del precio a una hora y propagé el intervalo a los componentes que muestran el estado.
- Rediseñé el header y el layout móvil con un menú compacto, espaciados más contenidos y tarjetas optimizadas.
- Añadí un radar de mercado global, métricas de volatilidad, exportación del histórico y gestor de alertas de precio en el dashboard.

## Testing
- npm run lint *(falla: faltan dependencias por restricciones de red)*


------
https://chatgpt.com/codex/tasks/task_e_68d39407398c8323b07fa53856efaa8d