### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -155,8 +155,8 @@
 
 @media (max-width: 600px) {
   .content-grid {
-    width: calc(100% - 1.5rem);
-    padding: 1.85rem 0 3.25rem;
+    width: calc(100% - 1.35rem);
+    padding: 1.75rem 0 3rem;
   }
 
   .content-grid::before {
@@ -168,9 +168,28 @@
   }
 }
 
+@media (max-width: 520px) {
+  .content-grid {
+    width: calc(100% - 1.1rem);
+    gap: 1.6rem;
+    padding: 1.6rem 0 2.75rem;
+  }
+
+  .content-grid::before {
+    inset: 0.35rem;
+    border-radius: 1.5rem;
+  }
+
+  .card {
+    padding: 1.35rem;
+    border-radius: 1.25rem;
+  }
+}
+
 @media (max-width: 460px) {
   .card {
-    padding: 1.3rem;
+    padding: 1.2rem;
+    border-radius: 1.15rem;
   }
 }
 

--- a/src/components/Calculator/Calculator.css
+++ b/src/components/Calculator/Calculator.css
@@ -350,6 +350,26 @@
   font-size: 0.9rem;
 }
 
+.calculator__schedule-table {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 0 -0.2rem;
+  padding-bottom: 0.35rem;
+}
+
+.calculator__schedule-table table {
+  min-width: 560px;
+}
+
+.calculator__schedule-table::-webkit-scrollbar {
+  height: 6px;
+}
+
+.calculator__schedule-table::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+}
+
 .calculator__schedule th,
 .calculator__schedule td {
   padding: 0.6rem 0.75rem;
@@ -482,6 +502,19 @@
     flex-direction: column;
     align-items: stretch;
   }
+
+  .calculator__scenario-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .calculator__scenario-stats {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .calculator__schedule-table {
+    margin: 0 -0.35rem;
+  }
 }
 
 @media (max-width: 600px) {
@@ -505,11 +538,19 @@
   .calculator__result-value {
     font-size: 1.9rem;
   }
+
+  .calculator__schedule-table table {
+    min-width: 520px;
+  }
 }
 
 @media (max-width: 480px) {
   .calculator__profile-form {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .calculator__schedule-table {
+    margin: 0 -0.5rem;
   }
 }

--- a/src/components/Calculator/Calculator.jsx
+++ b/src/components/Calculator/Calculator.jsx
@@ -593,28 +593,30 @@ export function Calculator({ price, source, loading, error, lastUpdated, onRefre
             </button>
           </div>
           {scheduleAvailable ? (
-            <table>
-              <thead>
-                <tr>
-                  <th scope="col">Fecha</th>
-                  <th scope="col">BTC</th>
-                  <th scope="col">Valor actual</th>
-                  <th scope="col">Escenario</th>
-                  <th scope="col">Saldo restante</th>
-                </tr>
-              </thead>
-              <tbody>
-                {schedule.map((item) => (
-                  <tr key={item.id}>
-                    <th scope="row">{item.label}</th>
-                    <td>{item.amountLabel}</td>
-                    <td>{item.eurLabel}</td>
-                    <td>{item.projectedLabel}</td>
-                    <td>{item.remainingLabel}</td>
+            <div className="calculator__schedule-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Fecha</th>
+                    <th scope="col">BTC</th>
+                    <th scope="col">Valor actual</th>
+                    <th scope="col">Escenario</th>
+                    <th scope="col">Saldo restante</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {schedule.map((item) => (
+                    <tr key={item.id}>
+                      <th scope="row">{item.label}</th>
+                      <td>{item.amountLabel}</td>
+                      <td>{item.eurLabel}</td>
+                      <td>{item.projectedLabel}</td>
+                      <td>{item.remainingLabel}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           ) : (
             <p className="help">
               Configura una fecha futura y libera BTC retirables para generar el calendario.

--- a/src/components/Dashboard/Dashboard.css
+++ b/src/components/Dashboard/Dashboard.css
@@ -502,6 +502,14 @@
   .dashboard__target-progress-label {
     margin-left: 0;
   }
+
+  .dashboard__insights {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dashboard__metrics {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
 }
 
 @media (max-width: 640px) {
@@ -521,5 +529,55 @@
 
   .dashboard__footer {
     justify-content: center;
+  }
+
+  .dashboard__chart {
+    height: 240px;
+    padding: 1rem;
+  }
+
+  .dashboard__refresh,
+  .dashboard__pulse,
+  .dashboard__targets,
+  .dashboard__resources {
+    padding: 0.95rem;
+  }
+
+  .dashboard__target-heading {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .dashboard__target-remove {
+    width: 100%;
+  }
+
+  .dashboard__target-meta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 520px) {
+  .dashboard__metrics {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dashboard__recent-item {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.6rem;
+  }
+
+  .dashboard__chip {
+    justify-self: stretch;
+    text-align: center;
+  }
+
+  .dashboard__refresh-header {
+    align-items: stretch;
+  }
+
+  .dashboard__refresh-time {
+    align-self: flex-start;
   }
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -246,6 +246,88 @@
 
   .header__badge {
     width: 100%;
+    min-width: 0;
+  }
+
+  .header__refresh {
+    width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .header__inner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .header__brand {
+    align-items: flex-start;
+    gap: 0.65rem;
+  }
+
+  .header__controls {
+    width: 100%;
+    justify-content: space-between;
+    align-items: stretch;
+  }
+
+  .header__menu-toggle {
+    margin-left: auto;
+    align-self: flex-end;
+  }
+}
+
+@media (max-width: 640px) {
+  .header__brand-copy h1 {
+    font-size: 1.25rem;
+  }
+
+  .header__brand-copy p {
+    font-size: 0.82rem;
+  }
+
+  .header__meta {
+    display: grid;
+    gap: 0.85rem;
+    position: static;
+    min-width: 0;
+    width: 100%;
+    margin-top: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 1rem;
+    background: transparent;
+    box-shadow: none;
+    opacity: 0;
+    pointer-events: none;
+    transform: none;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.25s ease, opacity 0.2s ease, padding 0.2s ease;
+  }
+
+  .header__meta--open {
+    opacity: 1;
+    pointer-events: auto;
+    max-height: 640px;
+    margin-top: 0.6rem;
+    padding: 0.85rem;
+    background: rgba(8, 12, 24, 0.92);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 1rem;
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.38);
+  }
+
+  .header__actions {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .header__status {
+    display: grid;
+    gap: 0.75rem;
+    width: 100%;
   }
 
   .header__refresh {
@@ -264,5 +346,32 @@
 
   .header__brand-copy p {
     font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .header__inner {
+    padding: 0.6rem 0.85rem;
+  }
+
+  .header__brand {
+    gap: 0.55rem;
+  }
+
+  .header__brand-copy h1 {
+    font-size: 1.15rem;
+  }
+
+  .header__brand-copy p {
+    font-size: 0.78rem;
+  }
+
+  .header__badge-label {
+    font-size: 0.88rem;
+  }
+
+  .header__badge-source,
+  .header__badge-time {
+    font-size: 0.72rem;
   }
 }


### PR DESCRIPTION
## Summary
- adjust global spacing and card styling to better fit narrow screens
- rework the header layout so navigation and status sections collapse cleanly on phones
- make the calculator schedule horizontally scrollable and stack dashboard widgets on smaller viewports

## Testing
- `npm install` *(fails: 403 Forbidden when downloading recharts from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a64ad4708323ac0072d496e6aa3c